### PR TITLE
Regenerate revocation list credential for new URL

### DIFF
--- a/fixtures/revocationList.json
+++ b/fixtures/revocationList.json
@@ -3,13 +3,13 @@
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/vc-revocation-list-2020/v1"
     ],
-    "id": "https://w3c-ccg.github.io/vc-http-api/fixtures/revocationList.json",
+    "id": "https://w3c-ccg.github.io/vc-api/fixtures/revocationList.json",
     "type": [
       "VerifiableCredential",
       "RevocationList2020Credential"
     ],
     "issuer": {
-      "id": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3"
+      "id": "did:key:z6MknzD3XyJNXWBjHTKxp8HqtsRnbazPRowYcSzHFuRF74B5"
     },
     "issuanceDate": "2021-02-15T07:50:03.050Z",
     "credentialSubject": {
@@ -18,9 +18,9 @@
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2021-02-15T07:50:03Z",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..qN657PZcI21d3hZsjlHaINGMJ0URuP9Lo8-0vYqNrPK6WEOB1SsegmyFSwRMcvyrKpWfcorpBsDFLwdwcVHNBA",
+      "created": "2021-10-29T19:12:09Z",
+      "jws": "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..TDjNe7qv39-U1y2clIEz38w9BjIkW3PLVl-xEiXbhqD9KhtTvX2r74Xmi6uCmMMTiFsn03sXLwQr6mYwPN4tCw",
       "proofPurpose": "assertionMethod",
-      "verificationMethod": "did:key:z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3#z6MkiY62766b1LJkExWMsM3QG4WtX7QpY823dxoYzr9qZvJ3"
+      "verificationMethod": "did:key:z6MknzD3XyJNXWBjHTKxp8HqtsRnbazPRowYcSzHFuRF74B5#z6MknzD3XyJNXWBjHTKxp8HqtsRnbazPRowYcSzHFuRF74B5"
     }
 }


### PR DESCRIPTION
Address #236

A corresponding PR to update the verifiable credentials using the revocation list is here: https://github.com/w3c-ccg/vc-api-test-suite/pull/10.

This uses a new key I generated locally, as I have not access to the existing key. Is this a correct approach?