### PR TITLE
Remove created from VerifyOptions

### DIFF
--- a/components/VerifyOptions.yml
+++ b/components/VerifyOptions.yml
@@ -23,9 +23,6 @@ components:
         proofPurpose:
           type: string
           description: The purpose of the proof. Default 'assertionMethod'.
-        created:
-          type: string
-          description: The date and time of the proof (with a maximum accuracy in seconds). Default current system time.
         challenge:
           type: string
           description: A challenge provided by the requesting party of the proof. For example 6e62f66e-67de-11eb-b490-ef3eeefa55f2


### PR DESCRIPTION
Fix #68 as proposed in https://github.com/w3c-ccg/vc-api/issues/68#issuecomment-964581687 and discussed on the [2021-11-09 VC API work item call](https://w3c-ccg.github.io/meetings/2021-11-09-vcapi/).

Related: #253 (Remove verificationMethod from VerifyOptions)