### PR TITLE
Remove verificationMethod from VerifyOptions

### DIFF
--- a/components/VerifyOptions.yml
+++ b/components/VerifyOptions.yml
@@ -17,9 +17,6 @@ components:
       additionalProperties: false
       description: Options for specifying how the LinkedDataProof is verified.
       properties:
-        verificationMethod:
-          type: string
-          description: The URI of the verificationMethod used for the proof. Default assertionMethod URI.
         proofPurpose:
           type: string
           description: The purpose of the proof. Default 'assertionMethod'.


### PR DESCRIPTION
When verifying, being able to specify a verificationMethod as an option can be dangerous, see discussion in https://github.com/w3c-ccg/vc-api/pull/248.