### PR TITLE
Enable transaction identifiers to be multibase encoded 128-bit numbers.

### DIFF
--- a/components/parameters/path/TransactionId.yml
+++ b/components/parameters/path/TransactionId.yml
@@ -1,0 +1,10 @@
+in: path
+name: transaction-id
+required: true
+schema:
+  type: string
+  pattern: "(z[1-9A-HJ-NP-Za-km-z]{21,22})|(u[a-zA-Z0-9_-]{22,23})|([0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12})"
+example:
+  - f37e5114-8b4a-11ec-b32e-fbd62b9502c1
+  - z4Z1T4HdLdfXCFAhdhzdCqm
+  - u7m8_ybOArXaEWeADqWCsIw

--- a/components/parameters/path/TransactionId.yml
+++ b/components/parameters/path/TransactionId.yml
@@ -2,9 +2,14 @@ in: path
 name: transaction-id
 required: true
 schema:
-  type: string
-  pattern: "(z[1-9A-HJ-NP-Za-km-z]{21,22})|(u[a-zA-Z0-9_-]{22,23})|([0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12})"
+  anyOf:
+    - type: string
+      pattern: "[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}"
+    - type: string
+      pattern: "z[1-9A-HJ-NP-Za-km-z]{21,22}"
+    - type: string
+      pattern: "u[a-zA-Z0-9_-]{22,23}"
 example:
   - f37e5114-8b4a-11ec-b32e-fbd62b9502c1
   - z4Z1T4HdLdfXCFAhdhzdCqm
-  - u7m8_ybOArXaEWeADqWCsIw
+  - u7m8_ybOArX-EWeADqWCsIw

--- a/components/parameters/path/TransactionUuid.yml
+++ b/components/parameters/path/TransactionUuid.yml
@@ -1,6 +1,0 @@
-in: path
-name: transaction-uuid
-required: true
-schema:
-  type: string
-  pattern: "([0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}){0,1}"

--- a/holder.yml
+++ b/holder.yml
@@ -100,17 +100,17 @@ paths:
           description: Service not implemented.
         "500":
           description: Internal server error.
-  /exchanges/{exchange-id}/{transaction-uuid}:
+  /exchanges/{exchange-id}/{transaction-id}:
     put:
       summary: Receives information related to an existing exchange.
       operationId: receiveExchangeData
       description:
         A client can use this endpoint to continue the exchange of information
-        associated with an initiated exchange by sending a Verifiable Presentation 
+        associated with an initiated exchange by sending a Verifiable Presentation
         with information requested by the server to this endpoint.
       parameters:
         - $ref: "./components/parameters/path/ExchangeId.yml"
-        - $ref: "./components/parameters/path/TransactionUuid.yml"
+        - $ref: "./components/parameters/path/TransactionId.yml"
       requestBody:
         description:
           A Verifiable Presentation.

--- a/index.html
+++ b/index.html
@@ -533,7 +533,7 @@ The following APIs are defined for presenting a Verifiable Credential:
       <table class="simple api-summary-table"
         data-api-path="
           /credentials/derive /presentations/prove
-          /exchanges/{exchange-id} /exchanges/{exchange-id}/{transaction-uuid}"
+          /exchanges/{exchange-id} /exchanges/{exchange-id}/{transaction-id}"
         ></table>
 
       <section>
@@ -569,7 +569,7 @@ The following APIs are defined for presenting a Verifiable Credential:
         </p>
 
         <div class="api-detail"
-          data-api-endpoint="put /exchanges/{exchange-id}/{transaction-uuid}"></div>
+          data-api-endpoint="put /exchanges/{exchange-id}/{transaction-id}"></div>
       </section>
 
       <section>


### PR DESCRIPTION
This PR expands the range of transaction identifiers to allow for multibase (base58btc and base64url) encoded 128-bit numbers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/262.html" title="Last updated on Feb 16, 2022, 11:05 PM UTC (d667a0c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/262/7b43c72...d667a0c.html" title="Last updated on Feb 16, 2022, 11:05 PM UTC (d667a0c)">Diff</a>