### PR TITLE
Remove issue VC option to change verification method.

### DIFF
--- a/components/IssueCredentialOptions.yml
+++ b/components/IssueCredentialOptions.yml
@@ -20,9 +20,6 @@ components:
         type:
           type: string
           description: The type of the proof. Default is an appropriate proof type corresponding to the verification method.
-        verificationMethod:
-          type: string
-          description: The URI of the verificationMethod used for the proof. If omitted, a default verification method will be used.
         proofPurpose:
           type: string
           description: The purpose of the proof. Default 'assertionMethod'.
@@ -45,7 +42,6 @@ components:
       example:
         {
           "type": "Ed25519Signature2018",
-          "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
           "proofPurpose": "assertionMethod",
           "created": "2020-04-02T18:48:36Z",
           "domain": "revocation.example",


### PR DESCRIPTION
I do not think it should be possible to change the verification method when issuing a VC.

I think the chosen VC issuer endpoint should have a valid configuration that is known to the caller of the API. If a different cryptosuite is a requirement for the caller, a different URL should be hit that has a different configuration, for example:

Configuration 1: `<myserver>/issuers/123/credentials/issue`
Configuration 2: `<myserver>/issuers/456/credentials/issue`

A client should only care that the VC that is issued has an expected `issuer` field and it uses an acceptable cryptosuite and credential status mechanism. Any further details of how these things are implemented are not the client's responsibility -- and I believe that making them so constitutes a layering violation and leads to trouble. The parties that setup issuer endpoints should have to think deliberately about which configurations they are offering, as well. For example, there are important privacy considerations.

To further support this argument:

1. Consider if the party that setup the issuer needs to rotate keys -- it would need to update or notify all clients that use that endpoint to make changes. Additionally, there is now more information a client may need to know and configure in order to use the issuer service vs. just setting a URL (and any authz credentials).
2. Consider if the client chooses a "sub configuration" that leads to incompatibilities. For example, a client chooses to issue a VC using a verification method or cryptosuite X -- but the credential status method results in a status list credential that is signed with verification or cryptosuite Y. Now consumers that were expecting to be able to verify using X cannot check status without using Y (or there is some business policy violation). This could be made even worse if the issuer service uses the same VM to issue both the requested VC and the status list VC -- changing up the verification method used on the static list VC based on whatever the latest issued VC was. To remedy this, the issuer services may need to validate all possible different "sub configuration" combinations resulting in unnecessary complexity to meet use cases.
3. Allowing any possible parameter to be configured by the client absolves the party that configures the issuer instances to avoid thinking about privacy considerations: Offering many different possible cryptosuites can result in harming the herd privacy afforded by credential status lists VCs.

I'm generally in favor of reducing the options that a client can make when hitting an issuer URL -- leaving most, if not all, options up to a configuration that is pinned to the URL. This PR just starts with "verification method" as I see it as the most immediately problematic.