### PR TITLE
Clarify that exchange-id/transaction-id are opaque to client.

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,6 +536,13 @@ The following APIs are defined for presenting a Verifiable Credential:
           /exchanges/{exchange-id} /exchanges/{exchange-id}/{transaction-id}"
         ></table>
 
+        <p class="advisement">
+The URL path values <code>exchange-id</code> and <code>transaction-id</code> are
+meaningful to the server but are opaque to the client. While some server
+implementations might use values that happen to be human-readable,  clients are
+strongly advised to not assign semantics to any human-readable values.
+        </p>
+
       <section>
         <h4>Derive Credential</h4>
         <p>


### PR DESCRIPTION
This PR addresses the following ACTION I took last month: https://w3c-ccg.github.io/meetings/2022-02-15-vcapi/#action-1

> ACTION: Manu to articulate why transaction-id is an expression of a 128-bit number that is meaningful to the server, but opaque to the client, and how we might open up the range of values later.

I chose to not articulate that it was a 128-bit number since I've heard some rumblings that folks would like the option that it can be a different/larger value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/269.html" title="Last updated on Mar 13, 2022, 3:35 PM UTC (7b3180c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/269/bfa77bd...7b3180c.html" title="Last updated on Mar 13, 2022, 3:35 PM UTC (7b3180c)">Diff</a>