### PR TITLE
Fix Presentation endpoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -559,7 +559,7 @@ The following APIs are defined for presenting a Verifiable Credential:
         data-api-path="
           /credentials/derive /presentations/prove
           /presentations /presentations/{id}
-          /exchanges/{exchange-id} /exchanges/{exchange-id}/{transaction-id}"
+          /exchanges/ /exchanges/{exchange-id} /exchanges/{exchange-id}/{transaction-id}"
         ></table>
 
         <p class="advisement">
@@ -614,7 +614,7 @@ the exchange discovery endpoint.
         </p>
 
         <div class="api-detail"
-          data-api-endpoint="get /credentials/{id}"></div>
+          data-api-endpoint="get /presentations/{id}"></div>
       </section>
       
       <section>


### PR DESCRIPTION
There seems to be a typo in the "[Get a specific Presentation](https://w3c-ccg.github.io/vc-api/#get-a-specific-presentation)" section.

The exchange discovery endpoint is missing from the "[Presenting](https://w3c-ccg.github.io/vc-api/#presenting)" summary.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/matthieubosquet/vc-api/pull/309.html" title="Last updated on Oct 11, 2022, 9:23 AM UTC (2294aca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/309/9219bd6...matthieubosquet:2294aca.html" title="Last updated on Oct 11, 2022, 9:23 AM UTC (2294aca)">Diff</a>