### PR TITLE
POST /credentials/issue should return an object with property verifiableCredential

### DIFF
--- a/issuer.yml
+++ b/issuer.yml
@@ -66,7 +66,10 @@ components:
         options:
           $ref: "./components/IssueCredentialOptions.yml#/components/schemas/IssueCredentialOptions"
     IssueCredentialResponse:
-      $ref: "./components/VerifiableCredential.yml#/components/schemas/VerifiableCredential"
+      type: object
+      properties:
+        verifiableCredential:
+          $ref: "./components/VerifiableCredential.yml#/components/schemas/VerifiableCredential"
     UpdateCredentialStatus:
       type: object
       description: Request for updating the status of an issued credential.

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -1,4 +1,5 @@
 function getEndpoint({apis, path}) {
+console.log('getEndpoint', {apis, path});
   let endpoint = {
     post: {
       summary: 'Error: API Endpoint not defined - ' + path

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -1,5 +1,4 @@
 function getEndpoint({apis, path}) {
-console.log('getEndpoint', {apis, path});
   let endpoint = {
     post: {
       summary: 'Error: API Endpoint not defined - ' + path


### PR DESCRIPTION
Instead of returning the Vc as the response body itself we now return an object of the form:

```js
{
  verifiableCredential: {
    ...Vc
  }
}
```

This does not change the property used to issue a credential which remains `credential` as the group seems to have settled on `credential` for an unsigned Vc and `verifiableCredential` for a signed Vc with a proof. Returning the Vc in the property `verifiableCredential` also opens up the possibility of return error codes and other error information which should make testing easier.

Related: https://github.com/w3c-ccg/vc-api/issues/291

This does not add metadata as consensus on what that metadata should look like has not been reached.
+1 to using a metadata pattern similar to did resolution.