### PR TITLE
Add OAuth2 to securitySchemes for holder, issuer, & verifier.

### DIFF
--- a/components/oauth2.yml
+++ b/components/oauth2.yml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  version: "0.0.3-unstable"
+  title: VC API
+  description: This is an Experimental Open API Specification for the [VC Data Model](https://www.w3.org/TR/vc-data-model/).
+  license:
+    name: W3C Software and Document License
+    url: http://www.w3.org/Consortium/Legal/copyright-software.
+  contact:
+    name: GitHub Source Code
+    url: https://github.com/w3c-ccg/vc-api
+paths:
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token

--- a/holder.yml
+++ b/holder.yml
@@ -414,6 +414,9 @@ paths:
           description: Service not implemented.
 
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "./components/oauth2.yml#/components/securitySchemes/OAuth2"
   schemas:
     DeriveCredentialRequest:
       type: object

--- a/issuer.yml
+++ b/issuer.yml
@@ -17,6 +17,8 @@ paths:
        - Credentials
       operationId: issueCredential
       description: Issues a credential and returns it in the response body.
+      security:
+        - OAuth2: []
       requestBody:
         content:
           application/json:
@@ -32,6 +34,10 @@ paths:
                 $ref: "#/components/schemas/IssueCredentialResponse"
         "400":
           description: invalid input!
+        "401":
+          description: Missing or invalid auth credentials.
+        "403":
+          description: Incorrect scope or permissions.
         "500":
           description: error!
   /credentials/status:
@@ -41,6 +47,8 @@ paths:
        - Credentials
       operationId: updateCredentialStatus
       description: Updates the status of an issued credential.
+      security:
+        - OAuth2: []
       requestBody:
         content:
           application/json:
@@ -52,11 +60,18 @@ paths:
           description: Credential status successfully updated
         "400":
           description: Bad Request
+        "401":
+          description: Missing or invalid auth credentials.
+        "403":
+          description: Incorrect scope or permissions.
         "404":
           description: Credential not found
         "500":
           description: Internal Server Error
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "./components/oauth2.yml#/components/securitySchemes/OAuth2"
   schemas:
     IssueCredentialRequest:
       type: object

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -48,12 +48,18 @@ function buildEndpointDetails({config, document, apis}) {
     // detail each API endpoint
     const [verb, path] = section.dataset.apiEndpoint.split(/\s+/);
     const endpoint = getEndpoint({apis, path})[verb];
-
     // summary for endpoint
     const summary = document.createElement('p');
     summary.innerHTML =
       verb.toUpperCase() + ' ' + path + ' - ' + endpoint.summary;
     section.appendChild(summary);
+    if(Array.isArray(endpoint.security)) {
+      const security = document.createElement('p');
+      security.innerHTML = 'Authorization - ' + endpoint.security.flatMap(entry =>
+        Object.entries(entry).map(([key, value]) => `${key} ${value?.length ? ':' + value : ''}`)
+      )
+      section.appendChild(security);
+    }
 
     // responses for endpoint
     const responsesTable = document.createElement('table');

--- a/verifier.yml
+++ b/verifier.yml
@@ -17,6 +17,8 @@ paths:
        - Credentials
       operationId: verifyCredential
       description: Verifies a verifiableCredential and returns a verificationResult in the response body.
+      security:
+        - OAuth2: []
       requestBody:
         content:
           application/json:
@@ -32,6 +34,10 @@ paths:
                 $ref: "#/components/schemas/VerifyCredentialResponse"
         "400":
           description: invalid input!
+        "401":
+          description: Missing or invalid auth credentials.
+        "403":
+          description: Incorrect scope or permissions.
         "500":
           description: error!
   /presentations/verify:
@@ -41,6 +47,8 @@ paths:
        - Presentations
       operationId: verifyPresentation
       description: Verifies a verifiablePresentation and returns a verificationResult in the response body.  Given the possibility of denial of service, buffer overflow, or other style attacks, an implementation is permitted to rate limit or restrict requests against this API endpoint to those requests that contain only a single credential with a 413 or 429 error code as appropriate.
+      security:
+        - OAuth2: []
       requestBody:
         content:
           application/json:
@@ -58,6 +66,10 @@ paths:
                 $ref: "#/components/schemas/VerifyPresentationResponse"
         "400":
           description: Invalid or malformed input
+        "401":
+          description: Missing or invalid auth credentials.
+        "403":
+          description: Incorrect scope or permissions.
         "413":
           description: Payload too large
         "429":
@@ -65,6 +77,9 @@ paths:
         "500":
           description: Internal Server Error
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "./components/oauth2.yml#/components/securitySchemes/OAuth2"
   schemas:
     VerifyCredentialRequest:
       type: object


### PR DESCRIPTION
This borrows the `OAuth2` stuff from traceability and abstracts it into the `VC-API`.

This adds `OAuth2` to all of the paths in issuer.

This is a DRAFT PR for a variety of reasons:

- [x] the auth details don't show up in the `index.html` and most of the `api/*.html` pages
- [x] We probably want to add `OAuth2` to other paths/ routes, but I'm not sure if it goes on all of them
- [ ] We might want to add a `Zcap` auith component too