### PR TITLE
Add 404 as a response for GET/DELETE credentials/{id} and same for VPs

### DIFF
--- a/holder.yml
+++ b/holder.yml
@@ -31,6 +31,8 @@ paths:
           description: Bad Request
         "401":
           description: Not Authorized
+        "404":
+          description: Credential not found
         "410":
           description: Gone! There is no data here
         "418":
@@ -53,6 +55,8 @@ paths:
           description: Bad Request
         "401":
           description: Not Authorized
+        "404":
+          description: Credential not found
         "410":
           description: Gone! There is no data here
         "500":
@@ -143,6 +147,8 @@ paths:
           description: Bad Request
         "401":
           description: Not Authorized
+        "404":
+          description: Presentation not found
         "410":
           description: Gone! There is no data here
         "500":
@@ -163,6 +169,8 @@ paths:
           description: Bad Request
         "401":
           description: Not Authorized
+        "404":
+          description: Presentation not found
         "410":
           description: Gone! There is no data here
         "500":


### PR DESCRIPTION
This is a draft and for discussion purposes only.
It does not represent the consensus of the group.

This adds 404 responses to the following endpoints:

- GET /presentations/{id} - Gets a presentation or verifiable presentation by ID
- DELETE /credentials/{id} - Delete a credential or verifiable credential by ID
- GET /presentations/{id}
- DELETE /presentations/{id}