### PR TITLE
Add verifiablePresentation to exchanges examples.

### DIFF
--- a/index.html
+++ b/index.html
@@ -779,57 +779,59 @@ Accept: application/json, */*
 Accept-Encoding: gzip, deflate
 
 {
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1",
-    "https://w3id.org/security/suites/ed25519-2020/v1"
-  ],
-  "type": ["VerifiablePresentation"],
-  "holder": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-  "verifiableCredential": [{
+  "verifiablePresentation": {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
       "https://www.w3.org/2018/credentials/examples/v1",
       "https://w3id.org/security/suites/ed25519-2020/v1"
     ],
-    "id": "http://example.edu/credentials/3732",
-    "type": [
-      "VerifiableCredential",
-      "UniversityDegreeCredential"
-    ],
-    "issuer": "https://example.edu/issuers/14",
-    "issuanceDate": "2010-01-01T19:23:24Z",
-    "expirationDate": "2022-01-01T19:23:24Z",
-    "credentialSubject": {
-      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-      "degree": {
-        "type": "BachelorDegree",
-        "name": "Bachelor of Science and Arts"
+    "type": ["VerifiablePresentation"],
+    "holder": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "verifiableCredential": [{
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1",
+        "https://w3id.org/security/suites/ed25519-2020/v1"
+      ],
+      "id": "http://example.edu/credentials/3732",
+      "type": [
+        "VerifiableCredential",
+        "UniversityDegreeCredential"
+      ],
+      "issuer": "https://example.edu/issuers/14",
+      "issuanceDate": "2010-01-01T19:23:24Z",
+      "expirationDate": "2022-01-01T19:23:24Z",
+      "credentialSubject": {
+        "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+        "degree": {
+          "type": "BachelorDegree",
+          "name": "Bachelor of Science and Arts"
+        }
+      },
+      "refreshService": {
+        "type": "AutoRefresh2021",
+        "url": "https://example.edu/exchanges/refresh-degree",
+        "validAfter": "2021-09-01T19:23:24Z"
+      },
+      "proof": {
+        "type": "Ed25519Signature2020",
+        "created": "2021-12-05T17:59:45Z",
+        "verificationMethod": "https://example.edu/issuers/14#key-1",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "z2aArNcQKX9aqYK7GRZmV7c9xfGuwB5YAXhkYY9DTvLdTCQEsXaNpz1G
+                       ZL9XDXdFQGT27WB68e2Y3wo9k75rka8oo"
       }
-    },
-    "refreshService": {
-      "type": "AutoRefresh2021",
-      "url": "https://example.edu/exchanges/refresh-degree",
-      "validAfter": "2021-09-01T19:23:24Z"
-    },
+    }],
     "proof": {
       "type": "Ed25519Signature2020",
-      "created": "2021-12-05T17:59:45Z",
-      "verificationMethod": "https://example.edu/issuers/14#key-1",
-      "proofPurpose": "assertionMethod",
-      "proofValue": "z2aArNcQKX9aqYK7GRZmV7c9xfGuwB5YAXhkYY9DTvLdTCQEsXaNpz1G
-                     ZL9XDXdFQGT27WB68e2Y3wo9k75rka8oo"
+      "created": "2022-06-15T16:37:12Z",
+      "verificationMethod": "did:example:76e12ec712ebc6f1c221ebfeb1f#key-1",
+      "proofPurpose": "authentication",
+      "challenge": "3182bdea-63d9-11ea-b6de-3b7c1404d57f",
+      "domain": "example.edu",
+      "proofValue": "z4aU6NSpnCvnjJqzAPw3cqJ1LKoWimEWxKz7StJYzwaZE2a3QAuK8vcq
+                     umwr6uabr7RshvjH1yTv1fTuhPUii1fN"
     }
-  }],
-  "proof": {
-    "type": "Ed25519Signature2020",
-    "created": "2022-06-15T16:37:12Z",
-    "verificationMethod": "did:example:76e12ec712ebc6f1c221ebfeb1f#key-1",
-    "proofPurpose": "authentication",
-    "challenge": "3182bdea-63d9-11ea-b6de-3b7c1404d57f",
-    "domain": "example.edu",
-    "proofValue": "z4aU6NSpnCvnjJqzAPw3cqJ1LKoWimEWxKz7StJYzwaZE2a3QAuK8vcq
-                   umwr6uabr7RshvjH1yTv1fTuhPUii1fN"
   }
 }
         </pre>
@@ -841,47 +843,49 @@ Date: Fri, 14 Jun 2022 18:37:12 GMT
 Connection: keep-alive
 
 {
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1"
-  ],
-  "type": ["VerifiablePresentation"],
-  "verifiableCredential": [{
+  "verifiablePresentation": {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      "https://www.w3.org/2018/credentials/examples/v1",
-      "https://w3id.org/security/suites/ed25519-2020/v1"
+      "https://www.w3.org/2018/credentials/examples/v1"
     ],
-    "id": "http://example.edu/credentials/3732",
-    "type": [
-      "VerifiableCredential",
-      "UniversityDegreeCredential"
-    ],
-    "issuer": "https://example.edu/issuers/14",
-    "issuanceDate": "2010-01-01T19:23:24Z",
-    "expirationDate": "2027-06-14T18:37:12Z",
-    "credentialSubject": {
-      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-      "degree": {
-        "type": "BachelorDegree",
-        "name": "Bachelor of Science and Arts"
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [{
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1",
+        "https://w3id.org/security/suites/ed25519-2020/v1"
+      ],
+      "id": "http://example.edu/credentials/3732",
+      "type": [
+        "VerifiableCredential",
+        "UniversityDegreeCredential"
+      ],
+      "issuer": "https://example.edu/issuers/14",
+      "issuanceDate": "2010-01-01T19:23:24Z",
+      "expirationDate": "2027-06-14T18:37:12Z",
+      "credentialSubject": {
+        "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+        "degree": {
+          "type": "BachelorDegree",
+          "name": "Bachelor of Science and Arts"
+        }
+      },
+      "refreshService": {
+        "type": "AutoRefresh2021",
+        "url": "https://example.edu/exchanges/refresh-degree",
+        "validAfter": "2027-03-14T19:23:24Z",
+        "validUntil": "2027-07-14T19:23:24Z"
+      },
+      "proof": {
+        "type": "Ed25519Signature2020",
+        "created": "2022-06-14T18:37:12Z",
+        "verificationMethod": "https://example.edu/issuers/14#key-1",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "z2aArNcQKX9aqYK7GRZmV7c9xfGuwB5YAXhkYY9DTvLdTCQEsXaNpz1G
+                       ZL9XDXdFQGT27WB68e2Y3wo9k75rka8oo"
       }
-    },
-    "refreshService": {
-      "type": "AutoRefresh2021",
-      "url": "https://example.edu/exchanges/refresh-degree",
-      "validAfter": "2027-03-14T19:23:24Z",
-      "validUntil": "2027-07-14T19:23:24Z"
-    },
-    "proof": {
-      "type": "Ed25519Signature2020",
-      "created": "2022-06-14T18:37:12Z",
-      "verificationMethod": "https://example.edu/issuers/14#key-1",
-      "proofPurpose": "assertionMethod",
-      "proofValue": "z2aArNcQKX9aqYK7GRZmV7c9xfGuwB5YAXhkYY9DTvLdTCQEsXaNpz1G
-                     ZL9XDXdFQGT27WB68e2Y3wo9k75rka8oo"
-    }
-  }]
+    }]
+  }
 }
         </pre>
       </section>


### PR DESCRIPTION
This corrects a mistake where the exchange examples didn't match the `exchanges continue` schema.

Addresses: https://github.com/w3c-ccg/vc-api/issues/311


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/vc-api/pull/322.html" title="Last updated on Nov 4, 2022, 3:38 PM UTC (024d3cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/322/f12d687...aljones15:024d3cd.html" title="Last updated on Nov 4, 2022, 3:38 PM UTC (024d3cd)">Diff</a>