### PR TITLE
Add verifiablePresentationRequest property to exchange initiate.

### DIFF
--- a/holder.yml
+++ b/holder.yml
@@ -526,7 +526,10 @@ components:
     StorePresentationRequest:
       $ref: "./components/VerifiablePresentation.yml#/components/schemas/VerifiablePresentation"
     VerifiablePresentationRequest:
-      $ref: "./components/VerifiablePresentationRequest.yml#/components/schemas/VerifiablePresentationRequest"
+      type: object
+      properties:
+        verifiablePresentationRequest:
+          $ref: "./components/VerifiablePresentationRequest.yml#/components/schemas/VerifiablePresentationRequest"
     VerifiablePresentationResponse:
       type: object
       properties:


### PR DESCRIPTION
This matches the response schema for `exchanges initiate` so that it matches the examples.
The change made is that the `exchanges initiate` response now has a property: `verifiablePresentationRequest`.
This is a DRAFT PR as discussion might need to be made on if the examples are wrong or the schema is wrong.