### PR TITLE
Adds a description to issuer.id & the error response.

### DIFF
--- a/components/ErrorResponse.yml
+++ b/components/ErrorResponse.yml
@@ -19,12 +19,15 @@ components:
         id:
           type: "string"
           pattern: "[a-z0-9\\-]{8,}"
+          description: An error id.
         message:
           type: "string"
           minLength: 10
           maxLength: 100
+          description: The error message.
         details:
           type: "object"
+          description: An object with error details.
       required: ["id", "message"]
       example:
         {

--- a/components/Issuer.yml
+++ b/components/Issuer.yml
@@ -21,5 +21,6 @@ components:
           properties:
             id:
               type: string
+              description: The issuer id.
       example:
         { "id": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd" }


### PR DESCRIPTION
Corrects a small bug where schema properties with out a description had `undefined` in them in the `index.html`.