### PR TITLE
Expand introductory section to include purpose of spec.

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,43 +147,41 @@ model and serialization to express digital credentials in a way that is
 cryptographically secure, privacy respecting, and machine-verifiable. This
 specification provides a set of HTTP Application Programming Interfaces (HTTP
 APIs) and protocols for issuing, verifying, presenting, and managing Verifiable
-Credentials in such an ecosystem.
+Credentials.
     </p>
 
     <p>
 When managing <a>verifiable credentials</a>, there are two general types of APIs
-that are contemplated. The first type of APIs are ones that are internal to a
-particular security domain. The second type of APIs are ones that are used to
-communicate between two different security domains. This specification defines
+that are contemplated. The first type of APIs are designed to be used within
+a single security domain. The second type of APIs can be used to
+communicate across different security domains. This specification defines
 both types of APIs.
     </p>
 
     <p>
-APIs that are internal to a security domain are used by systems that are
-operating on behalf of a particular role such as an Issuer, Verifier, or Holder.
-Even though it is not strictly necessary to define these APIs, there are
-benefits to doing so. One such benefit is that it is useful for the Verifiable
-Credentials ecosystem to have a common understanding of a useful internal
-architectures in a security domain when it comes to managing Verifiable
-Credentials. For example, it can be helpful to software architects to
-understanding what a vetted internal architecture and API looks like when it
-comes to issuing a <a>verifiable credential</a> such that they can speak a
-common language when performing internal systems integration tasks. Knowing that
+The APIs that are designed to be used within a single security domain are used by
+systems that are operating on behalf of a single role such as an Issuer, Verifier,
+or Holder. One benefit of these APIs for the Verifiable Credentials ecosystem
+is that they define a useful, common, and vetted modular architecture for
+managing Verifiable Credentials. For example, this approach helps software
+architects integrate with common components and speak a common language
+when implementing systems that issue <a>verifiable credentials</a>. Knowing that
 a particular architecture has been vetted is also beneficial for architects that
 do not specialize in <a>verifiable credentials</a>. Documented architectures and
-APIs also increase market competition and reduce vendor lock-in and switching
-costs when it comes to selecting vendor solutions.
+APIs increase market competition and reduce vendor lock-in and switching
+costs.
     </p>
 
     <p>
-APIs that are external to a security domain are used by systems that are
-communicating between two different roles in a <a>verifiable credential</a>
-ecosystem, such as an API that is used to communicate presentations between a
-Holder and a Verifier. In order to achieve protocol interoperability in the
-<a>verifiable credentials</a> ecosystem, it is vital that these APIs be
-standardized. The benefits of documenting these APIs are the same for
-documenting the internal APIs; common, vetted architecture and APIs, increased
-market competition, reduced vendor lock-in and switching costs.
+The APIs that are designed to operate across multiple security domains are
+used by systems that are communicating between two different roles in a
+<a>verifiable credential</a> interaction, such as an API that is used to
+communicate presentations between a Holder and a Verifier. In order to
+achieve protocol interoperability in <a>verifiable credentials</a> interactions,
+it is vital that these APIs be standardized. The additional benefits of
+documenting these APIs are the same for documenting the
+single-security-domain APIs: common, vetted architecture and APIs, increased
+market competition, and reduced vendor lock-in and switching costs.
     </p>
 
     <p>
@@ -209,11 +207,11 @@ the document.
 that can be used with the API.
       </li>
       <li>
-<a href="#issuing"></a> describes both the internal and external APIs for
+<a href="#issuing"></a> describes the APIs for
 issuing <a>verifiable credentials</a> as well as updating their status.
       </li>
       <li>
-<a href="#verifying"></a> specifies the internal APIs for verifying both
+<a href="#verifying"></a> specifies the APIs for verifying both
 <a>verifiable credentials</a> and verifiable presentations.
       </li>
       <li>

--- a/index.html
+++ b/index.html
@@ -140,7 +140,50 @@ to <a href="mailto:public-credentials@w3.org">public-credentials@w3.org</a> (
 
   <section class="informative">
     <h1>Introduction</h1>
+
     <p>
+The Verifiable Credentials specification [[VC-DATA-MODEL-2.0]] provides a data
+model and serialization to express digital credentials in a way that is
+cryptographically secure, privacy respecting, and machine-verifiable. This
+specification provides a set of HTTP Application Programming Interfaces (HTTP
+APIs) and protocols for issuing, verifying, presenting, and managing Verifiable
+Credentials in such an ecosystem.
+    </p>
+
+    <p>
+When managing <a>verifiable credentials</a>, there are two general types of APIs
+that are contemplated. The first type of APIs are ones that are internal to a
+particular security domain. The second type of APIs are ones that are used to
+communicate between two different security domains. This specification defines
+both types of APIs.
+    </p>
+
+    <p>
+APIs that are internal to a security domain are used by systems that are
+operating on behalf of a particular role such as an Issuer, Verifier, or Holder.
+Even though it is not strictly necessary to define these APIs, there are
+benefits to doing so. One such benefit is that it is useful for the Verifiable
+Credentials ecosystem to have a common understanding of a useful internal
+architectures in a security domain when it comes to managing Verifiable
+Credentials. For example, it can be helpful to software architects to
+understanding what a vetted internal architecture and API looks like when it
+comes to issuing a <a>verifiable credential</a> such that they can speak a
+common language when performing internal systems integration tasks. Knowing that
+a particular architecture has been vetted is also beneficial for architects that
+do not specialize in <a>verifiable credentials</a>. Documented architectures and
+APIs also increase market competition and reduce vendor lock-in and switching
+costs when it comes to selecting vendor solutions.
+    </p>
+
+    <p>
+APIs that are external to a security domain are used by systems that are
+communicating between two different roles in a <a>verifiable credential</a>
+ecosystem, such as an API that is used to communicate presentations between a
+Holder and a Verifier. In order to achieve protocol interoperability in the
+<a>verifiable credentials</a> ecosystem, it is vital that these APIs be
+standardized. The benefits of documenting these APIs are the same for
+documenting the internal APIs; common, vetted architecture and APIs, increased
+market competition, reduced vendor lock-in and switching costs.
     </p>
 
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -186,6 +186,48 @@ documenting the internal APIs; common, vetted architecture and APIs, increased
 market competition, reduced vendor lock-in and switching costs.
     </p>
 
+    <p>
+This specification contains the following sections that software architects
+and implementers might find useful:
+    </p>
+
+    <ul class="bullet">
+      <li>
+<a href="#design-goals"></a> specifies the high level design goals
+that drove the formulation of this specification.
+      </li>
+      <li>
+<a href="#architecture-overview"></a> highlights the different roles
+and components that are contemplated by the architecture.
+      </li>
+      <li>
+<a href="#terminology"></a> defines specific terms that are used throughout
+the document.
+      </li>
+      <li>
+<a href="#authorization"></a> elaborates upon the various forms of authorization
+that can be used with the API.
+      </li>
+      <li>
+<a href="#issuing"></a> describes both the internal and external APIs for
+issuing <a>verifiable credentials</a> as well as updating their status.
+      </li>
+      <li>
+<a href="#verifying"></a> specifies the internal APIs for verifying both
+<a>verifiable credentials</a> and verifiable presentations.
+      </li>
+      <li>
+<a href="#presenting"></a> defines both the internal and external APIs for
+generating, deriving, and exchanging verifiable presentations.
+      </li>
+      <li>
+Finally, Appendix <a href="#privacy-considerations"></a>, and
+<a href="#security-considerations"></a> are provided to highlight factors
+that implementers might consider when building systems that utilize the APIs
+defined by this specification.
+      </li>
+    </ul>
+
     <section class="informative">
       <h2>Design Goals</h2>
 

--- a/index.html
+++ b/index.html
@@ -215,8 +215,9 @@ issuing <a>verifiable credentials</a> as well as updating their status.
 <a>verifiable credentials</a> and verifiable presentations.
       </li>
       <li>
-<a href="#presenting"></a> defines both the internal and external APIs for
-generating, deriving, and exchanging verifiable presentations.
+<a href="#presenting"></a> defines APIs for generating and deriving
+<a>verifiable presentations</a> within a trust domain, as well as
+exchanging <a>verifiable presentations</a> across trust domains.
       </li>
       <li>
 Finally, Appendix <a href="#privacy-considerations"></a>, and

--- a/terms.html
+++ b/terms.html
@@ -29,7 +29,7 @@ defined by [[RFC3986]]. A <a>DID</a> is a type of URI scheme.
   <dd>
 A standard data model and representation format for cryptographically-verifiable
 digital credentials as defined by the W3C Verifiable Credentials specification
-[[VC-DATA-MODEL]].
+[[VC-DATA-MODEL-2.0]].
   </dd>
 
   <dt><dfn data-lt="UUID|UUIDs">Universally Unique Identifier</dfn> (UUID)</dt>


### PR DESCRIPTION
This PR adds an introductory section to the VC API specification including the reasoning behind having VC APIs defined that are both internal to a single security domain and ones used to communicate between two different security domains.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 522  :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 21, 2023, 6:16 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c-ccg%2Fvc-api%2F93b26f2ee8b3dc3e7276eb169baac8c706ce3ee4%2Findex.html%3FisPreview%3Dtrue)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c-ccg/vc-api%23328.)._
</details>
