### PR TITLE
Fix linting errors in OAS files.

### DIFF
--- a/components/SecuritySchemes.yml
+++ b/components/SecuritySchemes.yml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  version: "0.0.3-unstable"
+  title: VC API
+  description: This is an Experimental Open API Specification for the [VC Data Model](https://www.w3.org/TR/vc-data-model/).
+  license:
+    name: W3C Software and Document License
+    url: http://www.w3.org/Consortium/Legal/copyright-software.
+  contact:
+    name: GitHub Source Code
+    url: https://github.com/w3c-ccg/vc-api
+paths:
+components:
+  securitySchemes:
+    noAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: VerifiablePresentation
+
+    zCap:
+      type: http
+      scheme: bearer
+      bearerFormat: VerifiablePresentation
+
+
+    didAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: VerifiablePresentation
+
+    oAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: /oauth2/authorize
+          tokenUrl: /oauth2/token
+          scopes:
+            read: Grants read access
+            write: Grants write access

--- a/components/SecuritySchemes.yml
+++ b/components/SecuritySchemes.yml
@@ -15,13 +15,12 @@ components:
     noAuth:
       type: http
       scheme: bearer
-      bearerFormat: VerifiablePresentation
+      bearerFormat: emptyString
 
     zCap:
       type: http
-      scheme: bearer
-      bearerFormat: VerifiablePresentation
-
+      scheme: signature
+      bearerFormat: AuthorizationCapability
 
     didAuth:
       type: http

--- a/components/SecuritySchemes.yml
+++ b/components/SecuritySchemes.yml
@@ -12,10 +12,9 @@ info:
 paths:
 components:
   securitySchemes:
-    noAuth:
+    networkAuth:
       type: http
-      scheme: bearer
-      bearerFormat: emptyString
+      scheme: sourceIpAccessRules
 
     zCap:
       type: http
@@ -28,11 +27,5 @@ components:
       bearerFormat: VerifiablePresentation
 
     oAuth2:
-      type: oauth2
-      flows:
-        authorizationCode:
-          authorizationUrl: /oauth2/authorize
-          tokenUrl: /oauth2/token
-          scopes:
-            read: Grants read access
-            write: Grants write access
+      type: http
+      scheme: bearer

--- a/components/SecuritySchemes.yml
+++ b/components/SecuritySchemes.yml
@@ -24,7 +24,7 @@ components:
 
     didAuth:
       type: http
-      scheme: bearer
+      scheme: signature
       bearerFormat: VerifiablePresentation
 
     oAuth2:

--- a/holder.yml
+++ b/holder.yml
@@ -18,7 +18,7 @@ paths:
       tags:
        - Credentials
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       summary: Gets a credential or verifiable credential by ID
@@ -52,7 +52,7 @@ paths:
       tags:
        - Credentials
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       summary: Deletes a credential or verifiable credential by ID
@@ -79,7 +79,7 @@ paths:
       tags:
        - Credentials
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       summary: Gets list of credentials or verifiable credentials
@@ -119,7 +119,7 @@ paths:
       tags:
        - Credentials
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       summary: Derives a credential and returns it in the response body.
@@ -151,7 +151,7 @@ paths:
        - Presentations
       summary: Gets a presentation or verifiable presentation by ID
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       operationId: getPresentation
@@ -183,7 +183,7 @@ paths:
        - Presentations
       summary: Deletes a presentation or verifiable presentation by ID
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       operationId: deletePresentation
@@ -210,7 +210,7 @@ paths:
        - Presentations
       summary: Gets list of presentations or verifiable presentations
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       operationId: getPresentations
@@ -251,7 +251,7 @@ paths:
       tags:
        - Presentations
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       operationId: provePresentation
@@ -279,7 +279,7 @@ paths:
       tags:
        - Exchanges
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       operationId: discoverExchanges
@@ -382,7 +382,7 @@ paths:
       tags:
        - Exchanges
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       operationId: initiateExchange
@@ -432,7 +432,7 @@ paths:
       tags:
        - Exchanges
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
        - didAuth: []

--- a/holder.yml
+++ b/holder.yml
@@ -1,4 +1,7 @@
 openapi: 3.0.0
+servers:
+  - url: https://verifier.qa.veres.app/verifiers/z1A45ZhWEGMeibHrB15nv8Gk6
+    description: Veres Verifier (Quality Assurance)
 info:
   version: "0.0.3-unstable"
   title: VC Holder API
@@ -14,6 +17,10 @@ paths:
     get:
       tags:
        - Credentials
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       summary: Gets a credential or verifiable credential by ID
       operationId: getCredential
       parameters:
@@ -44,6 +51,10 @@ paths:
     delete:
       tags:
        - Credentials
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       summary: Deletes a credential or verifiable credential by ID
       operationId: deleteCredential
       parameters:
@@ -67,6 +78,10 @@ paths:
     get:
       tags:
        - Credentials
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       summary: Gets list of credentials or verifiable credentials
       operationId: getCredentials
       parameters:
@@ -103,6 +118,10 @@ paths:
     post:
       tags:
        - Credentials
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       summary: Derives a credential and returns it in the response body.
       operationId: deriveCredential
       description: Derives a credential and returns it in the response body.
@@ -131,6 +150,10 @@ paths:
       tags:
        - Presentations
       summary: Gets a presentation or verifiable presentation by ID
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: getPresentation
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
@@ -159,6 +182,10 @@ paths:
       tags:
        - Presentations
       summary: Deletes a presentation or verifiable presentation by ID
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: deletePresentation
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
@@ -182,6 +209,10 @@ paths:
       tags:
        - Presentations
       summary: Gets list of presentations or verifiable presentations
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: getPresentations
       parameters:
         - in: query
@@ -219,6 +250,10 @@ paths:
       summary: Proves a presentation and returns it in the response body.
       tags:
        - Presentations
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: provePresentation
       description: Proves a presentation and returns it in the response body.
       requestBody:
@@ -243,26 +278,30 @@ paths:
       summary: Provides a discovery endpoint for the exchanges supported by this server endpoint.
       tags:
        - Exchanges
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: discoverExchanges
-      description: 
-        This endpoint returns an array of the exchange-ids (path endpoints) supported by this server, 
+      description:
+        This endpoint returns an array of the exchange-ids (path endpoints) supported by this server,
         and the associated protocol supported by that exchange endpoint. The list supports pagination.
-        Clients consuming this list wishing to use an exchange endpoint MUST recognize and support 
+        Clients consuming this list wishing to use an exchange endpoint MUST recognize and support
         the protocol identified in the value field. Clients are not expected to dynamically process
-        the protocol specified.   
+        the protocol specified.
       parameters:
         - name: index
           in: query
-          description: 
-            The starting index for the list that is meaningful to the server. 
+          description:
+            The starting index for the list that is meaningful to the server.
             If omitted the server must assume the start of the list.
           required: false
           schema:
             type: string
         - name: limit
           in: query
-          description: 
-            The maximum number of items to return in the response. If omitted the service should 
+          description:
+            The maximum number of items to return in the response. If omitted the service should
             return all remaining items from the start index.
           required: false
           schema:
@@ -301,13 +340,13 @@ paths:
                     properties:
                       self:
                         type: string
-                        description: 
-                          The index position of the start of the returned list. Examples could be a numerica value, 
+                        description:
+                          The index position of the start of the returned list. Examples could be a numerica value,
                           a URL, or a value meaningful to the server.
                       next:
                         type: string
-                        description: 
-                          The index position for the next set of results (ie, index of the end of this list). 
+                        description:
+                          The index position for the next set of results (ie, index of the end of this list).
                           Examples could be a numerica value, a URL, or a value meaningful to the server.
 
               example:
@@ -316,7 +355,7 @@ paths:
                   "total": 8,
                   "exchanges" : [
                     {
-                      "id" : "credential-refresh", 
+                      "id" : "credential-refresh",
                       "type": "CredentialRefresh2020"
                     },
                     {
@@ -325,16 +364,16 @@ paths:
                     },
                     {
                       "id" : "salad",
-                      "type" : "https://example.com/oas/my-salad.yml" 
+                      "type" : "https://example.com/oas/my-salad.yml"
                   }],
                   "index": {
-                    "self": 0,
-                    "next" : 3
+                    "self": "0",
+                    "next" : "3"
                   }
                 }
-        "400": 
+        "400":
           description: invalid input
-        "500" : 
+        "500" :
           description: error
 
   /exchanges/{exchange-id}:
@@ -342,6 +381,10 @@ paths:
       summary: Initiates an exchange of information.
       tags:
        - Exchanges
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: initiateExchange
       description:
         A client can use this endpoint to initiate an exchange of a particular
@@ -388,6 +431,11 @@ paths:
       summary: Receives information related to an existing exchange.
       tags:
        - Exchanges
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
+       - didAuth: []
       operationId: receiveExchangeData
       description:
         A client can use this endpoint to continue the exchange of information
@@ -426,6 +474,8 @@ paths:
           description: Service not implemented.
 
 components:
+  securitySchemes:
+    $ref: "./components/SecuritySchemes.yml#/components/securitySchemes"
   schemas:
     DeriveCredentialRequest:
       type: object

--- a/issuer.yml
+++ b/issuer.yml
@@ -1,4 +1,7 @@
 openapi: 3.0.0
+servers:
+  - url: https://issuer.qa.veres.app/issuers/z19mTE4x8KHRaQLgdoYwsfPnU
+    description: Veres Issuer (Quality Assurance)
 info:
   version: "0.0.3-unstable"
   title: VC Issuer API
@@ -13,8 +16,12 @@ paths:
   /credentials/issue:
     post:
       summary: Issues a credential and returns it in the response body.
-      tags: 
+      tags:
        - Credentials
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: issueCredential
       description: Issues a credential and returns it in the response body.
       requestBody:
@@ -37,8 +44,12 @@ paths:
   /credentials/status:
     post:
       summary: Updates the status of an issued credential
-      tags: 
+      tags:
        - Credentials
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: updateCredentialStatus
       description: Updates the status of an issued credential.
       requestBody:
@@ -57,6 +68,8 @@ paths:
         "500":
           description: Internal Server Error
 components:
+  securitySchemes:
+    $ref: "./components/SecuritySchemes.yml#/components/securitySchemes"
   schemas:
     IssueCredentialRequest:
       type: object

--- a/issuer.yml
+++ b/issuer.yml
@@ -19,7 +19,7 @@ paths:
       tags:
        - Credentials
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       operationId: issueCredential
@@ -47,7 +47,7 @@ paths:
       tags:
        - Credentials
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       operationId: updateCredentialStatus

--- a/verifier.yml
+++ b/verifier.yml
@@ -1,4 +1,7 @@
 openapi: 3.0.0
+servers:
+  - url: https://verifier.qa.veres.app/verifiers/z1A45ZhWEGMeibHrB15nv8Gk6
+    description: Veres Issuer (Quality Assurance)
 info:
   version: "0.0.3-unstable"
   title: VC Verifier API
@@ -13,8 +16,12 @@ paths:
   /credentials/verify:
     post:
       summary: Verifies a verifiableCredential and returns a verificationResult in the response body.
-      tags: 
+      tags:
        - Credentials
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: verifyCredential
       description: Verifies a verifiableCredential and returns a verificationResult in the response body.
       requestBody:
@@ -37,8 +44,12 @@ paths:
   /presentations/verify:
     post:
       summary: Verifies a Presentation with or without proofs attached and returns a verificationResult in the response body.
-      tags: 
+      tags:
        - Presentations
+      security:
+       - noAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: verifyPresentation
       description: Verifies a verifiablePresentation and returns a verificationResult in the response body.  Given the possibility of denial of service, buffer overflow, or other style attacks, an implementation is permitted to rate limit or restrict requests against this API endpoint to those requests that contain only a single credential with a 413 or 429 error code as appropriate.
       requestBody:
@@ -65,6 +76,8 @@ paths:
         "500":
           description: Internal Server Error
 components:
+  securitySchemes:
+    $ref: "./components/SecuritySchemes.yml#/components/securitySchemes"
   schemas:
     VerifyCredentialRequest:
       type: object

--- a/verifier.yml
+++ b/verifier.yml
@@ -19,7 +19,7 @@ paths:
       tags:
        - Credentials
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       operationId: verifyCredential
@@ -47,7 +47,7 @@ paths:
       tags:
        - Presentations
       security:
-       - noAuth: []
+       - networkAuth: []
        - oAuth2: []
        - zCap: []
       operationId: verifyPresentation


### PR DESCRIPTION
This PR fixes linting errors in the OAS files. OAS linting requires that every endpoint define security properties and at least one server endpoint. Reviewers should pay specific attention to this PR because it does add authorization mechanisms available on each endpoint, including noAuth, didAuth, oAuth2, and zCap (since the current set of implementers support at least one of those mechanisms, if not multiple). Setting this PR to draft so we can discuss.

The intent of this PR is NOT to establish the correct authz mechanisms for each endpoint, that will be done in a future PR. The goal here is to get "close enough" and then fine tune the authz mechanisms in a future PR. Do not take the authz mechanisms provided as anything more than a work in progress at this point in time.