### PR TITLE
add PR tips to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,9 +71,11 @@ rendering of API files*
 
 ### Pull request reviewers
 Reviewers should be added by the pull requester.
-A "healthy" number of reviewers is good.
+A "healthy" number of reviewers, usually at least 3 people 
+other than yourself, is good.
 
 ## Edit style guide
 The following are style tips when editing the specification.
 - Try to have max of 80 char (do hard wrap, not auto wrap)
-- Left justify text
+- Indent HTML to the proper level using two-spaces per level.
+- Left justify prose to the first column

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,12 @@ Reviewers should be added by the pull requester.
 A "healthy" number of reviewers, usually at least 3 people 
 other than yourself, is good.
 
+### Merging Pull Requests
+
+It is recommended to merge PR using a "Rebase merge", rather than a "Squash and merge".
+Merge commits are disabled in order maintain a linear commit history.
+"Rebase and merge" is prefered because it maintains the authorship and commit date information which can be important for determining intellectual property contributions.
+
 ## Edit style guide
 The following are style tips when editing the specification.
 - Try to have max of 80 char (do hard wrap, not auto wrap)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,14 @@ part in designing the feature, you can remove yourself with the above syntax.
 
 The following is informal guidance on how to contribute pull requests.
 
-Please note that even if the text in a PR isn't perfect, you are encouraged to submit it to submit it as a first step to allow others to comment and collaborate on it.
+Please note that even if the text in a PR isn't perfect, you are encouraged to
+submit it as a first step, to allow others to comment and collaborate on it.
 
 TODO: put a link to 2023-11-28 call where this information was covered.
 
 ### How to pick an issue for PR
 Look for the issues tagged with with "Ready for PR".
-Read through the issue and see if one has a good grasp of what is going on.
+Read through the issue and see if you have a good grasp of what is going on.
 
 ### Specification Syntax
 [ReSpec](https://respec.org/docs) is the language used to write the spec.
@@ -44,7 +45,7 @@ Therefore, the way to edit the specification is to edit HTML, following ReSpec s
 
 ### Key Files
 The key entry point is [index.html](./index.html).
-In many pull request, this may be the only file that is changed.
+In many pull requests, this is the only file that is changed.
 
 ### Commit Messages
 For commit messages:
@@ -52,19 +53,21 @@ For commit messages:
 - Use less than 50 characters
 
 ### Pull request branches
-If going to be editing can either make a fork or can ask for editing access to the repo
+To begin editing, you can make a fork or ask for editing access to the repo.
 If making a significant change, always make a new branch.
-It is advisable to put username in the branch name.
-- This makes it easier to know which branches to delete.
+It is generally advisable to put your username in the branch name; this makes
+it easier to know which branches to prune over time.
 
 ### Pull request descriptions
 
-This issue number should be included the PR description.
+Any associated issue number(s) should be included the PR description.
 
-There is automation which adds preview and diff links added to the description.
-This is done using a library called "PR Preview", which is configured in pr-preview.json.
+There is automation which adds `preview` and `diff` links to the PR description.
+This is done through GitHub "CI" or "Continuous Integration" by a library
+called `PR-Preview`, which is configured in `.pr-preview.json`.
 
-*Note: Some things are broken in preview & diff: images, rending of API files*
+***Note:** Some things are broken in preview & diff, such as images and 
+rendering of API files*
 
 ### Pull request reviewers
 Reviewers should be added by the pull requester.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,8 @@ The following is informal guidance on how to contribute pull requests.
 Please note that even if the text in a PR isn't perfect, you are encouraged to
 submit it as a first step, to allow others to comment and collaborate on it.
 
-A walkthrough session covering PR tips is available in the recording of the [2023-11-28 VC API call](https://meet.w3c-ccg.org/archives/w3c-ccg-vcapi-2023-11-28.mp4).
+A walkthrough session covering PR tips is available in the recording of the
+[2023-11-28 VC API call](https://meet.w3c-ccg.org/archives/w3c-ccg-vcapi-2023-11-28.mp4).
 
 ### How to pick an issue for PR
 Look for the issues tagged with with "Ready for PR".
@@ -72,16 +73,18 @@ rendering of API files*
 ### Pull request reviewers
 Reviewers should be added by the pull requester.
 A "healthy" number of reviewers, usually at least 3 people 
-other than yourself, is good.
+other than the PR author, is good.
 
 ### Merging Pull Requests
 
-It is recommended to merge PR using a "Rebase merge", rather than a "Squash and merge".
-Merge commits are disabled in order maintain a linear commit history.
-"Rebase and merge" is prefered because it maintains the authorship and commit date information which can be important for determining intellectual property contributions.
+PRs should be merged using a "Rebase merge", rather than a "Squash and merge".
+Merge commits are disabled to maintain a linear commit history.
+"Rebase and merge" is preferred because it maintains the authorship and commit
+date information which can be important for determining intellectual property
+contributions.
 
 ## Edit style guide
-The following are style tips when editing the specification.
+The following are style tips when editing the specification:
 - Try to have max of 80 char (do hard wrap, not auto wrap)
-- Indent HTML to the proper level using two-spaces per level.
+- Indent HTML to the proper level using two spaces per level.
 - Left justify prose to the first column

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The following is informal guidance on how to contribute pull requests.
 Please note that even if the text in a PR isn't perfect, you are encouraged to
 submit it as a first step, to allow others to comment and collaborate on it.
 
-TODO: put a link to 2023-11-28 call where this information was covered.
+A walkthrough session covering PR tips is available in the recording of the [2023-11-28 VC API call](https://meet.w3c-ccg.org/archives/w3c-ccg-vcapi-2023-11-28.mp4).
 
 ### How to pick an issue for PR
 Look for the issues tagged with with "Ready for PR".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,52 @@ If you added a contributor by mistake, you can remove them in a comment with:
 
 If you are making a pull request on behalf of someone else but you had no
 part in designing the feature, you can remove yourself with the above syntax.
+
+## Pull Request Guidance
+
+The following is informal guidance on how to contribute pull requests.
+
+Please note that even if the text in a PR isn't perfect, you are encouraged to submit it to submit it as a first step to allow others to comment and collaborate on it.
+
+TODO: put a link to 2023-11-28 call where this information was covered.
+
+### How to pick an issue for PR
+Look for the issues tagged with with "Ready for PR".
+Read through the issue and see if one has a good grasp of what is going on.
+
+### Specification Syntax
+[ReSpec](https://respec.org/docs) is the language used to write the spec.
+Therefore, the way to edit the specification is to edit HTML, following ReSpec syntax.
+
+### Key Files
+The key entry point is [index.html](./index.html).
+In many pull request, this may be the only file that is changed.
+
+### Commit Messages
+For commit messages:
+- Use "active voice"
+- Use less than 50 characters
+
+### Pull request branches
+If going to be editing can either make a fork or can ask for editing access to the repo
+If making a significant change, always make a new branch.
+It is advisable to put username in the branch name.
+- This makes it easier to know which branches to delete.
+
+### Pull request descriptions
+
+This issue number should be included the PR description.
+
+There is automation which adds preview and diff links added to the description.
+This is done using a library called "PR Preview", which is configured in pr-preview.json.
+
+*Note: Some things are broken in preview & diff: images, rending of API files*
+
+### Pull request reviewers
+Reviewers should be added by the pull requester.
+A "healthy" number of reviewers is good.
+
+## Edit style guide
+The following are style tips when editing the specification.
+- Try to have max of 80 char (do hard wrap, not auto wrap)
+- Left justify text


### PR DESCRIPTION
This PR adds informal tips on how to submit a PR.
I'm not 100% sure that these tips are useful enough to justify their maintenance effort if the PR guidance changes, but some of it may be. Glad to take on feedback on this point.
This PR has no associated github issue.

TODO:
- [x] confirm if the new text should be in CONTRIBUTING.md (it looks like this might be a standard doc that shouldn't be edited)
- [x] clean up a bit
- [x] link from README (not done at CONTRIBUTING.md is standard place to look for contributing instructions)