### PR TITLE
Rename LinkedDataProof to DataIntegrityProof.

### DIFF
--- a/components/DataIntegrityProof.yml
+++ b/components/DataIntegrityProof.yml
@@ -12,13 +12,16 @@ info:
 paths:
 components:
   schemas:
-    LinkedDataProof:
+    DataIntegrityProof:
       type: object
-      description: A JSON-LD Linked Data proof.
+      description: A Data Integrity Proof as defined by the W3C VC Data Integrity specification.
       properties:
         type:
           type: string
-          description: Linked Data Signature Suite used to produce proof.
+          description: Data Integrity proof type.
+        cryptosuite:
+          type: string
+          description: The name of the cryptographic suite.
         created:
           type: string
           description: Date the proof was created.
@@ -37,17 +40,15 @@ components:
         proofPurpose:
           type: string
           description: The purpose of the proof to be used with verificationMethod.
-        jws:
-          type: string
-          description: Detached JSON Web Signature.
         proofValue:
           type: string
           description: Value of the Linked Data proof.
       example:
         {
-          "type": "Ed25519Signature2018",
-          "created": "2020-04-02T18:28:08Z",
-          "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+          "type": "DataIntegrityProof",
+          "cryptosuite": "ecdsa-rdfc-2019",
+          "created": "2024-01-11T19:14:04Z",
+          "verificationMethod": "https://di.example/issuer#zDnaepBuvsQ8cpsWrVKw8fbpGpvPeNSjVPTWoq6cRqaYzBKVP",
           "proofPurpose": "assertionMethod",
-          "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
+          "proofValue": "zXb23ZkdakfJNUhiTEdwyE598X7RLrkjnXEADLQZ7vZyUGXX8cyJZRBkNw813SGsJHWrcpo4Y8hRJ7adYn35Eetq"
         }

--- a/components/DataIntegrityProof.yml
+++ b/components/DataIntegrityProof.yml
@@ -18,7 +18,7 @@ components:
       properties:
         type:
           type: string
-          description: Data Integrity proof type.
+          description: Data Integrity Proof type.
         cryptosuite:
           type: string
           description: The name of the cryptographic suite.

--- a/components/DeriveCredentialOptions.yml
+++ b/components/DeriveCredentialOptions.yml
@@ -19,7 +19,7 @@ components:
       properties:
         nonce:
           type: string
-          description: An encoded nonce provided by the holder of the credential to be included into the DataIntegrityProof.
+          description: An encoded nonce provided by the holder of the credential, to be included in the DataIntegrityProof.
       example:
         {
           "nonce": "lEixQKDQvRecCifKl789TQj+Ii6YWDLSwn3AxR0VpPJ1QV5htod/0VCchVf1zVM0y2E=",

--- a/components/DeriveCredentialOptions.yml
+++ b/components/DeriveCredentialOptions.yml
@@ -19,7 +19,7 @@ components:
       properties:
         nonce:
           type: string
-          description: An encoded nonce provided by the holder of the credential to be included into the LinkedDataProof.
+          description: An encoded nonce provided by the holder of the credential to be included into the DataIntegrityProof.
       example:
         {
           "nonce": "lEixQKDQvRecCifKl789TQj+Ii6YWDLSwn3AxR0VpPJ1QV5htod/0VCchVf1zVM0y2E=",

--- a/components/IssueCredentialOptions.yml
+++ b/components/IssueCredentialOptions.yml
@@ -15,7 +15,7 @@ components:
     IssueCredentialOptions:
       type: object
       additionalProperties: false
-      description: Options for specifying how the LinkedDataProof is created.
+      description: Options for specifying how the DataIntegrityProof is created.
       properties:
         created:
           type: string

--- a/components/PresentCredentialOptions.yml
+++ b/components/PresentCredentialOptions.yml
@@ -15,7 +15,7 @@ components:
     PresentCredentialOptions:
       type: object
       additionalProperties: false
-      description: Options for specifying how the LinkedDataProof is created.
+      description: Options for specifying how the DataIntegrityProof is created.
       properties:
         type:
           type: string

--- a/components/VerifiableCredential.yml
+++ b/components/VerifiableCredential.yml
@@ -20,7 +20,7 @@ components:
         - type: object
           properties:
             proof:
-              $ref: "./LinkedDataProof.yml#/components/schemas/LinkedDataProof"
+              $ref: "./DataIntegrityProof.yml#/components/schemas/DataIntegrityProof"
       example:
         {
           "@context":

--- a/components/VerifiablePresentation.yml
+++ b/components/VerifiablePresentation.yml
@@ -20,7 +20,7 @@ components:
         - type: object
           properties:
             proof:
-              $ref: "./LinkedDataProof.yml#/components/schemas/LinkedDataProof"
+              $ref: "./DataIntegrityProof.yml#/components/schemas/DataIntegrityProof"
       example:
         {
           "@context":

--- a/components/VerifyOptions.yml
+++ b/components/VerifyOptions.yml
@@ -15,7 +15,7 @@ components:
     VerifyOptions:
       type: object
       additionalProperties: false
-      description: Options for specifying how the LinkedDataProof is verified.
+      description: Options for specifying how the DataIntegrityProof is verified.
       properties:
         challenge:
           type: string


### PR DESCRIPTION
This PR attempts to address issue #194 by renaming the legacy "LinkedDataProof" mechanism to the new "DataIntegrityProof" mechanism being standardized by W3C's VCWG.