### PR TITLE
Issue #265 -Should issuer be optional when requesting a credential be…

### DIFF
--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -44,8 +44,57 @@ components:
         {
           "@context":
             [
-                "https://www.w3.org/2018/credentials/v1",
-                "https://www.w3.org/2018/credentials/examples/v1",
+              "https://www.w3.org/2018/credentials/v1",
+              "https://www.w3.org/2018/credentials/examples/v1",
+            ],
+          "id": "http://example.gov/credentials/3732",
+          "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+          "issuer": "did:example:123",
+          "issuanceDate": "2020-03-16T22:37:26.544Z",
+          "credentialSubject":
+            {
+              "id": "did:example:123",
+              "degree":
+                {
+                  "type": "BachelorDegree",
+                  "name": "Bachelor of Science and Arts",
+                },
+            },
+        }
+    IssueCredential:
+      type: object
+      description: A JSON-LD Verifiable Credential without a proof.
+      properties:
+        "@context":
+          type: array
+          description: The JSON-LD context of the credential.
+          items:
+            type: string
+        "id":
+          type: string
+          description: The ID of the credential.
+        "type":
+          type: array
+          description: The JSON-LD type of the credential.
+          items:
+            type: string
+        "issuer":
+          $ref: "./Issuer.yml#/components/schemas/IssuerRequest"
+        "issuanceDate":
+          type: string
+          description: The issuanceDate
+        "expirationDate":
+          type: string
+          description: The expirationDate
+        "credentialSubject":
+          type: object
+          description: The subject
+      example:
+        {
+          "@context":
+            [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://www.w3.org/2018/credentials/examples/v1",
             ],
           "id": "http://example.gov/credentials/3732",
           "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/components/Issuer.yml
+++ b/components/Issuer.yml
@@ -24,3 +24,15 @@ components:
               description: The issuer id.
       example:
         { "id": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd" }
+    IssuerRequest:
+      type: object
+      description: A JSON-LD Verifiable Credential Issuer. The presence of object 'issuer' is optional (SHOULD be omitted). If provided, it MUST adhere to the configuration requirements of the particular implementation. Implementations MUST be able to understand and process the supplied value in accordance with their configuration. In scenarios where multiple configurations exist for a specific endpoint, the 'issuer' object, if present, MAY be utilized to select among multiple potential issuers. In such cases, the provided 'issuer' value MUST align with the available configurations, allowing the implementation to appropriately determine the issuer for the specific endpoint. Implementations MUST ensure that the selected issuer aligns with their configuration and can be processed successfully.
+      oneOf:
+        - type: string
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The issuer id.
+      example:
+        { "id": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd" }

--- a/issuer.yml
+++ b/issuer.yml
@@ -17,11 +17,11 @@ paths:
     post:
       summary: Issues a credential and returns it in the response body.
       tags:
-       - Credentials
+        - Credentials
       security:
-       - networkAuth: []
-       - oAuth2: []
-       - zCap: []
+        - networkAuth: []
+        - oAuth2: []
+        - zCap: []
       operationId: issueCredential
       description: Issues a credential and returns it in the response body.
       requestBody:
@@ -38,18 +38,21 @@ paths:
               schema:
                 $ref: "#/components/schemas/IssueCredentialResponse"
         "400":
-          description: invalid input!
+          description: >
+            The request could not be processed due to one of the following reasons:
+                        - The provided value of 'issuer' does not match the expected configuration.
+                        - Another condition that results in a Bad Request.
         "500":
           description: error!
   /credentials/status:
     post:
       summary: Updates the status of an issued credential
       tags:
-       - Credentials
+        - Credentials
       security:
-       - networkAuth: []
-       - oAuth2: []
-       - zCap: []
+        - networkAuth: []
+        - oAuth2: []
+        - zCap: []
       operationId: updateCredentialStatus
       description: Updates the status of an issued credential.
       requestBody:
@@ -75,7 +78,7 @@ components:
       type: object
       properties:
         credential:
-          $ref: "./components/Credential.yml#/components/schemas/Credential"
+          $ref: "./components/Credential.yml#/components/schemas/IssueCredential"
         options:
           $ref: "./components/IssueCredentialOptions.yml#/components/schemas/IssueCredentialOptions"
     IssueCredentialResponse:


### PR DESCRIPTION
Issue #265 -Should issuer be optional when requesting a credential be issued.
- Added a description defining the optional use of issuer object when issuing a verifiable credential.

Issue #275 - There should be a test that confirms a 4xx error when a credential issuance is requested with an unsupported issuer

- Updated description of 400 error response on /credentials/issue