### PR TITLE
Add returnCredential option to VerifyOptions

### DIFF
--- a/components/VerificationResult.yml
+++ b/components/VerificationResult.yml
@@ -32,4 +32,7 @@ components:
           description: Errors
           items:
             type: string
+        verifiedCredential:
+          type: object
+          description: The verified credential
       example: { "checks": ["proof"], "warnings": [], "errors": [] }

--- a/components/VerifyOptions.yml
+++ b/components/VerifyOptions.yml
@@ -26,7 +26,7 @@ components:
         returnCredential:
           type: boolean
           description:
-            Should the verified credential be returned in the response.
+            Should the verified credential be returned in the response?
             If true, then the verified credential should be returned in the form in which it was verified.
             If false or not provided, then the verified credential should not be returned.
       example:

--- a/components/VerifyOptions.yml
+++ b/components/VerifyOptions.yml
@@ -23,6 +23,9 @@ components:
         domain:
           type: string
           description: The intended domain of validity for the proof. For example website.example
+        returnCredential:
+          type: boolean
+          description: Should the verified credential be returned in its canonical form.
       example:
         {
           "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
@@ -30,4 +33,5 @@ components:
           "created": "2020-04-02T18:48:36Z",
           "domain": "example.com",
           "challenge": "d436f0c8-fbd9-4e48-bbb2-55fc5d0920a8",
+          "returnCredential": true
         }

--- a/components/VerifyOptions.yml
+++ b/components/VerifyOptions.yml
@@ -25,7 +25,10 @@ components:
           description: The intended domain of validity for the proof. For example website.example
         returnCredential:
           type: boolean
-          description: Should the verified credential be returned in its canonical form.
+          description:
+            Should the verified credential be returned in the response.
+            If true, then the verified credential should be returned in the form in which it was verified.
+            If false or not provided, then the verified credential should not be returned.
       example:
         {
           "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -315,7 +315,7 @@ function renderJsonSchemaValue(property, value) {
     valueRendering =
       `The <code>${property}</code> object MUST be `;
     valueRendering += renderJsonSchemaObject(value);
-  } else if(value.type === 'string') {
+  } else if(value.type === 'string' || value.type === 'boolean') {
     // no-op
   } else {
     valueRendering = '<pre>' + JSON.stringify(value, null, 2) + '</pre>';


### PR DESCRIPTION
PR to address https://github.com/w3c-ccg/vc-api/issues/207

TODO:
- [x] Fix extra json that is showing up in `index.html`
- [x] Describe what "canonical form" means. clarified here: https://github.com/w3c-ccg/vc-api/issues/207#issuecomment-1954988441
- [x] Mention that the parameter is optional
- [x] Add return examples -> decided not to add `verifiedCredential` to example as it is an optional parameter
- [x] Add the feature to the `Verify Presentation` presentation end point -> I think it is better to do this in a separate PR