### PR TITLE
301 define oauth2 authorization mechanism

### DIFF
--- a/index.html
+++ b/index.html
@@ -644,8 +644,8 @@ to request the access tokens. However, OAuth 2.0 MUST be implemented in the foll
 way:
         </p>
         <p>
-OAuth2 tokens for this purpose have an audience of the particular issuer instance:
-e.g. `origin/issuers/zc612332f3`.
+OAuth2 tokens for this purpose have an audience of the particular issuer instance,
+e.g., `origin/issuers/zc612332f3`.
         </p>
         <p>
 The scopes are generalized to read/write actions on particular endpoints:
@@ -662,7 +662,7 @@ The scopes are generalized to read/write actions on particular endpoints:
 `write:/credentials/issue` would only allow writing to that particular API.
         </p>
         <p>
-Other authorization mechanisms that support delegation may be defined in the future.
+Other authorization mechanisms that support delegation might be defined in the future.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -638,9 +638,28 @@ HTTP Basic Authentication [[RFC7617]].
         <h4>OAuth 2.0</h4>
         <p>
 If the OAuth 2.0 Authorization Framework [[RFC6749]] is utilized for authorization,
-the access tokens utilized by clients MAY be OAuth 2.0 Bearer Tokens [[RFC6750]]
-or any other valid OAuth 2.0 token type. Any valid OAuth 2.0 grant type MAY be used
-to request the access tokens.
+it MUST be implemented in the following way.
+        </p>
+        <p>
+OAuth2 tokens for this purpose have an audience of the particular issuer instance:
+e.g. `origin/issuers/zc612332f3`.
+        </p>
+        <p>
+The scopes are generalized to read/write actions on particular endpoints:
+        </p>
+        <ul>
+          <li>
+            `read:/` would allow reading on any API on a particular instance.
+          </li>
+          <li>
+            `write:/` would allow writing on any API on a particular instance.
+          </li>
+        </ul>
+        <p>
+`write:/credentials/issue` would only allow writing to that particular API.
+        </p>
+        <p>
+Other authorization mechanisms that support delegation may be defined in the future.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -638,7 +638,10 @@ HTTP Basic Authentication [[RFC7617]].
         <h4>OAuth 2.0</h4>
         <p>
 If the OAuth 2.0 Authorization Framework [[RFC6749]] is utilized for authorization,
-it MUST be implemented in the following way.
+the access tokens utilized by clients MAY be OAuth 2.0 Bearer Tokens [[RFC6750]]
+or any other valid OAuth 2.0 token type. Any valid OAuth 2.0 grant type MAY be used
+to request the access tokens. However, OAuth 2.0 MUST be implemented in the following 
+way:
         </p>
         <p>
 OAuth2 tokens for this purpose have an audience of the particular issuer instance:


### PR DESCRIPTION
Defines the mechanism by which OAuth2 can be used as an authorization technology for VC APIs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/369.html" title="Last updated on Feb 27, 2024, 8:21 PM UTC (6f7949d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/369/8a94c1f...6f7949d.html" title="Last updated on Feb 27, 2024, 8:21 PM UTC (6f7949d)">Diff</a>