### PR TITLE
Add general discussion of `options`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -645,6 +645,16 @@ to request the access tokens.
       </section>
 
     </section>
+    <section>
+      <h3>Options</h3>
+      <p>
+Some of the endpoints defined in the following sections accept an `options` object.
+None of the properties in `options` are required for any endpoint, as these properties
+are intended to meet per-configuration needs that may vary. However, configuration may
+prohibit some options from being used in order to preclude clients from passing certain
+data to a given configuration.
+      </p>
+    </section>
 
     <section>
       <h3>Issuing</h3>

--- a/index.html
+++ b/index.html
@@ -649,11 +649,12 @@ to request the access tokens.
       <h3>Options</h3>
       <p>
 Some of the endpoints defined in the following sections accept an `options` object.
-The `options` properties are OPTIONAL for every endpoint, as these properties
-are intended to meet per-configuration needs that might vary. However, instance configurations MAY
-prohibit some options from being used in order to preclude clients from passing certain
-data to a given instance. Some configurations MAY also require some options to
-be passed.
+All properties of the `options` object are OPTIONAL when configuring each endpoint,
+as these properties are intended to meet per-deployment needs that might vary.
+Thus, any given endpoint configuration MAY prohibit client use of some `options`
+properties in order to prevent clients from passing certain data to that endpoint.
+Likewise, an endpoint configuration MAY require that clients include some `options`
+properties.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -649,7 +649,7 @@ to request the access tokens.
       <h3>Options</h3>
       <p>
 Some of the endpoints defined in the following sections accept an `options` object.
-None of the properties in `options` are required for any endpoint, as these properties
+The `options` properties are OPTIONAL for every endpoint, as these properties
 are intended to meet per-configuration needs that might vary. However, instance configurations MAY
 prohibit some options from being used in order to preclude clients from passing certain
 data to a given instance. Some configurations MAY also require some options to

--- a/index.html
+++ b/index.html
@@ -650,9 +650,10 @@ to request the access tokens.
       <p>
 Some of the endpoints defined in the following sections accept an `options` object.
 None of the properties in `options` are required for any endpoint, as these properties
-are intended to meet per-configuration needs that may vary. However, configuration may
+are intended to meet per-configuration needs that might vary. However, instance configurations MAY
 prohibit some options from being used in order to preclude clients from passing certain
-data to a given configuration.
+data to a given instance. Some configurations MAY also require some options to
+be passed.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -649,11 +649,11 @@ to request the access tokens.
       <h3>Options</h3>
       <p>
 Some of the endpoints defined in the following sections accept an `options` object.
-All properties of the `options` object are OPTIONAL when configuring each endpoint,
+All properties of the `options` object are OPTIONAL when configuring each instance,
 as these properties are intended to meet per-deployment needs that might vary.
-Thus, any given endpoint configuration MAY prohibit client use of some `options`
-properties in order to prevent clients from passing certain data to that endpoint.
-Likewise, an endpoint configuration MAY require that clients include some `options`
+Thus, any given instance configuration MAY prohibit client use of some `options`
+properties in order to prevent clients from passing certain data to that instance.
+Likewise, an instance configuration MAY require that clients include some `options`
 properties.
       </p>
     </section>


### PR DESCRIPTION
Add section explicitly stating that properties in `options` are not required for any endpoint, but that configuration may disallow clients from using specific options.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/370.html" title="Last updated on Mar 5, 2024, 8:10 PM UTC (d720962)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/370/8a94c1f...d720962.html" title="Last updated on Mar 5, 2024, 8:10 PM UTC (d720962)">Diff</a>