### PR TITLE
Add /challenges endpoint.

### DIFF
--- a/components/Challenge.yml
+++ b/components/Challenge.yml
@@ -34,35 +34,4 @@ components:
         uses:
           type: string
           description: The number of times options.challenge has been used
-    VerificationResultWithChallengeMetadata:
-      type: object
-      additionalProperties: false
-      description: Object summarizing a verification
-      properties:
-        checks:
-          type: array
-          description: The checks performed
-          items:
-            type: string
-        warnings:
-          type: array
-          description: Warnings
-          items:
-            type: string
-        errors:
-          type: array
-          description: Errors
-          items:
-            type: string
-        ChallengeVerificationMetadata:
-          type: object
-          additionalProperties: false
-          description: Metadata about the verification of options.challenge.
-          properties:
-            verified:
-              type: string
-              description: Whether verification of the challenge was successful
-            uses:
-              type: string
-              description: The number of times options.challenge has been used
 

--- a/components/Challenge.yml
+++ b/components/Challenge.yml
@@ -28,7 +28,7 @@ components:
         verified:
           type: string
           description: Whether verification of the challenge was successful
-        firstVerified:
+        firstVerifiedAt:
           type: string
           description: dateTimeStamp when the challenge was first verified.
         uses:

--- a/components/Challenge.yml
+++ b/components/Challenge.yml
@@ -1,0 +1,65 @@
+openapi: 3.0.0
+info:
+  version: "0.0.3-unstable"
+  title: VC API
+  description: This is an Experimental Open API Specification for the [VC Data Model](https://www.w3.org/TR/vc-data-model/).
+  license:
+    name: W3C Software and Document License
+    url: http://www.w3.org/Consortium/Legal/copyright-software.
+  contact:
+    name: GitHub Source Code
+    url: https://github.com/w3c-ccg/vc-api
+paths:
+components:
+  schemas:
+    CreateChallengeResult:
+      type: object
+      additionalProperties: false
+      description: Object containg a challenge
+      properties:
+        challenge:
+          type: string
+          description: The challenge value
+    ChallengeVerificationMetadata:
+      type: object
+      additionalProperties: false
+      description: Metadata about the verification of options.challenge.
+      properties:
+        verified:
+          type: string
+          description: Whether verification of the challenge was successful
+        uses:
+          type: string
+          description: The number of times options.challenge has been used
+    VerificationResultWithChallengeMetadata:
+      type: object
+      additionalProperties: false
+      description: Object summarizing a verification
+      properties:
+        checks:
+          type: array
+          description: The checks performed
+          items:
+            type: string
+        warnings:
+          type: array
+          description: Warnings
+          items:
+            type: string
+        errors:
+          type: array
+          description: Errors
+          items:
+            type: string
+        ChallengeVerificationMetadata:
+          type: object
+          additionalProperties: false
+          description: Metadata about the verification of options.challenge.
+          properties:
+            verified:
+              type: string
+              description: Whether verification of the challenge was successful
+            uses:
+              type: string
+              description: The number of times options.challenge has been used
+

--- a/components/Challenge.yml
+++ b/components/Challenge.yml
@@ -28,6 +28,9 @@ components:
         verified:
           type: string
           description: Whether verification of the challenge was successful
+        firstVerified:
+          type: string
+          description: dateTimeStamp when the challenge was first verified.
         uses:
           type: string
           description: The number of times options.challenge has been used

--- a/components/IssueCredentialOptions.yml
+++ b/components/IssueCredentialOptions.yml
@@ -20,12 +20,6 @@ components:
         created:
           type: string
           description: The date and time of the proof (with a maximum accuracy in seconds). Defaults to current system time.
-        challenge:
-          type: string
-          description: A challenge provided by the party requesting the proof. For example, 6e62f66e-67de-11eb-b490-ef3eeefa55f2
-        domain:
-          type: string
-          description: The intended domain of validity for the proof. For example, website.example
         mandatoryPointers:
           type: array
           items:

--- a/holder.yml
+++ b/holder.yml
@@ -268,7 +268,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/ProvePresentationResponse"
+                $ref: "#/components/schemas/ProvePresentationResponse"
         "400":
           description: invalid input!
         "500":

--- a/holder.yml
+++ b/holder.yml
@@ -268,7 +268,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProvePresentationResponse"
+                oneOf:
+                  - $ref: "#/components/schemas/ProvePresentationResponse"
+                  - $ref: "#/components/schemas/ProvePresentationResponseWithChallengeVerificationMetadata"
         "400":
           description: invalid input!
         "500":
@@ -504,6 +506,13 @@ components:
       properties:
         verifiablePresentation:
           $ref: "./components/VerifiablePresentation.yml#/components/schemas/VerifiablePresentation"
+    ProvePresentationResponseWithChallengeVerificationMetadata:
+      type: object
+      properties:
+        verifiablePresentation:
+          $ref: "./components/VerifiablePresentation.yml#/components/schemas/VerifiablePresentation"
+        ChallengeVerificationMetadata:
+          $ref: "./components/Challenge.yml#/components/schemas/ChallengeVerificationMetadata"
     NotifyPresentationAvailableRequest:
       type: object
       properties:

--- a/holder.yml
+++ b/holder.yml
@@ -268,9 +268,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/ProvePresentationResponse"
-                  - $ref: "#/components/schemas/ProvePresentationResponseWithChallengeVerificationMetadata"
+                  $ref: "#/components/schemas/ProvePresentationResponse"
         "400":
           description: invalid input!
         "500":
@@ -506,13 +504,6 @@ components:
       properties:
         verifiablePresentation:
           $ref: "./components/VerifiablePresentation.yml#/components/schemas/VerifiablePresentation"
-    ProvePresentationResponseWithChallengeVerificationMetadata:
-      type: object
-      properties:
-        verifiablePresentation:
-          $ref: "./components/VerifiablePresentation.yml#/components/schemas/VerifiablePresentation"
-        ChallengeVerificationMetadata:
-          $ref: "./components/Challenge.yml#/components/schemas/ChallengeVerificationMetadata"
     NotifyPresentationAvailableRequest:
       type: object
       properties:

--- a/index.html
+++ b/index.html
@@ -763,7 +763,7 @@ The following APIs are defined for verifying a Verifiable Credential:
         <div class="api-detail"
           data-api-endpoint="post /challenges"></div>
         <p>
-The issuer should track the number of times a challenge has been passed to an endpoint as `options.challenge`.
+The instance should create a challenge for use during verification and it should keep track of the number of times a challenge has been passed to verification endpoints as `options.challenge`.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -735,7 +735,7 @@ The following APIs are defined for verifying a Verifiable Credential:
       </p>
 
       <table class="simple api-summary-table"
-        data-api-path="/credentials/verify /presentations/verify"></table>
+        data-api-path="/credentials/verify /presentations/verify /challenges"></table>
 
       <section>
         <h4>Verify Credential</h4>
@@ -753,6 +753,18 @@ The following APIs are defined for verifying a Verifiable Credential:
 
         <div class="api-detail"
           data-api-endpoint="post /presentations/verify"></div>
+      </section>
+
+      <section>
+        <h4>Create Challenge</h4>
+        <p>
+        </p>
+
+        <div class="api-detail"
+          data-api-endpoint="post /challenges"></div>
+        <p>
+The issuer should track the number of times a challenge has been passed to an endpoint as `options.challenge`.
+        </p>
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -763,7 +763,7 @@ The following APIs are defined for verifying a Verifiable Credential:
         <div class="api-detail"
           data-api-endpoint="post /challenges"></div>
         <p>
-The instance should create a challenge for use during verification and it should keep track of the number of times a challenge has been passed to verification endpoints as `options.challenge`.
+The instance should create a challenge for use during verification, and track the number of times the challenge has been passed to verification endpoints as `options.challenge`.
         </p>
       </section>
 

--- a/verifier.yml
+++ b/verifier.yml
@@ -79,6 +79,10 @@ paths:
   /challenges:
     post:
       summary: Passing an empty body to this endpoint creates and returns a challenge string in the response body.
+      security:
+       - networkAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: challenge
       description: Creates a challenge to be used as `options.challenge` in future requests.
       responses:

--- a/verifier.yml
+++ b/verifier.yml
@@ -62,11 +62,11 @@ paths:
         description: Parameters for verifying a verifiablePresentation.
       responses:
         "200":
-            description: Verifiable Presentation successfully verified!
-            content:
-              application/json:
-                schema:
-                  $ref: "#/components/schemas/VerifyPresentationResponse"
+          description: Verifiable Presentation successfully verified!
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VerifyPresentationResponse"
 
         "400":
           description: Invalid or malformed input

--- a/verifier.yml
+++ b/verifier.yml
@@ -66,9 +66,8 @@ paths:
             content:
               application/json:
                 schema:
-                  oneOf:
-                    - $ref: "#/components/schemas/VerifyPresentationResponse"
-                    - $ref: "#/components/schemas/VerifyPresentationResponseWithChallengeMetadata"
+                  $ref: "#/components/schemas/VerifyPresentationResponse"
+
         "400":
           description: Invalid or malformed input
         "413":
@@ -118,7 +117,5 @@ components:
           $ref: "./components/Presentation.yml#/components/schemas/Presentation"
     VerifyPresentationResponse:
       $ref: "./components/VerificationResult.yml#/components/schemas/VerificationResult"
-    VerifyPresentationResponseWithChallengeMetadata:
-      $ref: "./components/Challenge.yml#/components/schemas/VerificationResultWithChallengeMetadata"
     CreateChallengeResponse:
       $ref: "./components/Challenge.yml#/components/schemas/CreateChallengeResult"

--- a/verifier.yml
+++ b/verifier.yml
@@ -62,11 +62,13 @@ paths:
         description: Parameters for verifying a verifiablePresentation.
       responses:
         "200":
-          description: Verifiable Presentation successfully verified!
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/VerifyPresentationResponse"
+            description: Verifiable Presentation successfully verified!
+            content:
+              application/json:
+                schema:
+                  oneOf:
+                    - $ref: "#/components/schemas/VerifyPresentationResponse"
+                    - $ref: "#/components/schemas/VerifyPresentationResponseWithChallengeMetadata"
         "400":
           description: Invalid or malformed input
         "413":
@@ -75,6 +77,22 @@ paths:
           description: Request rate limit exceeded.
         "500":
           description: Internal Server Error
+  /challenges:
+    post:
+      summary: Passing an empty body to this endpoint creates and returns a challenge string in the response body.
+      operationId: challenge
+      description: Creates a challenge to be used as `options.challenge` in future requests.
+      responses:
+        "200":
+          description: Challenge created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateChallengeResponse"
+        "400":
+          description: Invalid or malformed input
+        "500":
+          description: Internal server error
 components:
   securitySchemes:
     $ref: "./components/SecuritySchemes.yml#/components/securitySchemes"
@@ -84,8 +102,6 @@ components:
       properties:
         verifiableCredential:
           $ref: "./components/VerifiableCredential.yml#/components/schemas/VerifiableCredential"
-        options:
-          $ref: "./components/VerifyOptions.yml#/components/schemas/VerifyOptions"
     VerifyCredentialResponse:
       $ref: "./components/VerificationResult.yml#/components/schemas/VerificationResult"
     VerifyPresentationRequest:
@@ -102,3 +118,7 @@ components:
           $ref: "./components/Presentation.yml#/components/schemas/Presentation"
     VerifyPresentationResponse:
       $ref: "./components/VerificationResult.yml#/components/schemas/VerificationResult"
+    VerifyPresentationResponseWithChallengeMetadata:
+      $ref: "./components/Challenge.yml#/components/schemas/VerificationResultWithChallengeMetadata"
+    CreateChallengeResponse:
+      $ref: "./components/Challenge.yml#/components/schemas/CreateChallengeResult"


### PR DESCRIPTION
- add challenge creation endpoint `\challenges`
- return `ChallengeVerificationMetadata` when `options.challenge` passed so client can track number of times challenge used
- remove passing `options.challenge` and `options.domain` to incorrect endpoints


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/373.html" title="Last updated on Mar 19, 2024, 6:52 PM UTC (4f34389)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/373/15a3e9b...4f34389.html" title="Last updated on Mar 19, 2024, 6:52 PM UTC (4f34389)">Diff</a>