### PR TITLE
Require `Content-Type: application/json` HTTP header.

### DIFF
--- a/index.html
+++ b/index.html
@@ -682,11 +682,7 @@ properties.
     <section>
       <h3>HTTP Headers</h3>
       <p>
-All requests and responses sent to/from the VC API that include entity bodies MUST
-contain the following header:
-      </p>      
-      <p>
-`Content-Type: application/json`</p>
+All requests and responses that include entity bodies sent to or received from the API endpoints defined by this specification MUST include the `Content-Type` header with a media type value of `application/json`.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -682,7 +682,8 @@ properties.
     <section>
       <h3>HTTP Headers</h3>
       <p>
-All requests and responses sent to/from the VC API MUST contain the following header:
+All requests and responses sent to/from the VC API that include entity bodies MUST
+contain the following header:
       </p>      
       <p>
 `Content-Type: application/json`</p>

--- a/index.html
+++ b/index.html
@@ -679,6 +679,15 @@ Likewise, an instance configuration MAY require that clients include some `optio
 properties.
       </p>
     </section>
+    <section>
+      <h3>HTTP Headers</h3>
+      <p>
+All requests and responses sent to/from the VC API MUST contain the following header:
+      </p>      
+      <p>
+`Content-Type: application/json`</p>
+      </p>
+    </section>
 
     <section>
       <h3>Issuing</h3>

--- a/index.html
+++ b/index.html
@@ -680,9 +680,9 @@ properties.
       </p>
     </section>
     <section>
-      <h3>HTTP Headers</h3>
+      <h3>Content Serialization</h3>
       <p>
-All requests and responses that include entity bodies sent to or received from the API endpoints defined by this specification MUST include the `Content-Type` header with a media type value of `application/json`.
+All entity bodies in requests and responses sent to or received from the API endpoints defined by this specification MUST be serialized as JSON and include the `Content-Type` header with a media type value of `application/json`. 
       </p>
     </section>
 


### PR DESCRIPTION
Adds normative text requiring that requests/responses have `Content-Type` set to `application/json`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/377.html" title="Last updated on Mar 26, 2024, 7:25 PM UTC (7a75f58)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/377/15a3e9b...7a75f58.html" title="Last updated on Mar 26, 2024, 7:25 PM UTC (7a75f58)">Diff</a>