### PR TITLE
update endpoint from Prove to create

### DIFF
--- a/holder.yml
+++ b/holder.yml
@@ -244,8 +244,6 @@ paths:
           description: Internal Error
         "501":
           description: Not Implemented
-
-  /presentations/:
     post:
       summary: Creates a presentation and returns it in the response body.
       tags:

--- a/holder.yml
+++ b/holder.yml
@@ -245,30 +245,30 @@ paths:
         "501":
           description: Not Implemented
 
-  /presentations/prove:
+  /presentations/:
     post:
-      summary: Proves a presentation and returns it in the response body.
+      summary: Creates a presentation and returns it in the response body.
       tags:
        - Presentations
       security:
        - networkAuth: []
        - oAuth2: []
        - zCap: []
-      operationId: provePresentation
-      description: Proves a presentation and returns it in the response body.
+      operationId: createPresentation
+      description: Creates a presentation and returns it in the response body.
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProvePresentationRequest"
-        description: Parameters for proving the presentation.
+              $ref: "#/components/schemas/CreatePresentationRequest"
+        description: Parameters for creating the presentation.
       responses:
         "201":
-          description: Presentation successfully proved!
+          description: Presentation successfully created!
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProvePresentationResponse"
+                $ref: "#/components/schemas/CreatePresentationResponse"
         "400":
           description: invalid input!
         "500":
@@ -492,14 +492,14 @@ components:
           $ref: "./components/DeriveCredentialOptions.yml#/components/schemas/DeriveCredentialOptions"
     DeriveCredentialResponse:
       $ref: "./components/VerifiableCredential.yml#/components/schemas/VerifiableCredential"
-    ProvePresentationRequest:
+    CreatePresentationRequest:
       type: object
       properties:
         presentation:
           $ref: "./components/Presentation.yml#/components/schemas/Presentation"
         options:
           $ref: "./components/PresentCredentialOptions.yml#/components/schemas/PresentCredentialOptions"
-    ProvePresentationResponse:
+    CreatePresentationResponse:
       type: object
       properties:
         verifiablePresentation:

--- a/index.html
+++ b/index.html
@@ -783,7 +783,7 @@ The following APIs are defined for presenting a Verifiable Credential:
 
       <table class="simple api-summary-table"
         data-api-path="
-          /credentials/derive /presentations/prove
+          /credentials/derive /presentations
           /presentations /presentations/{id}
           /exchanges/ /exchanges/{exchange-id} /exchanges/{exchange-id}/{transaction-id}"
         ></table>
@@ -805,12 +805,12 @@ strongly advised to not assign semantics to any human-readable values.
       </section>
 
       <section>
-        <h4>Prove Presentation</h4>
+        <h4>Create Presentation</h4>
         <p>
         </p>
 
         <div class="api-detail"
-          data-api-endpoint="post /presentations/prove"></div>
+          data-api-endpoint="post /presentations"></div>
       </section>
 
       <section>


### PR DESCRIPTION
Updates all references from proving a presentations to become creating a presentations. 
Changes endpoint from POST `presentations/prove` to POST `presentations`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/378.html" title="Last updated on Mar 26, 2024, 8:00 PM UTC (6d48c56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/378/ffe5571...6d48c56.html" title="Last updated on Mar 26, 2024, 8:00 PM UTC (6d48c56)">Diff</a>