### PR TITLE
Adding section that details API Endpoints by Component

### DIFF
--- a/exchanges.yml
+++ b/exchanges.yml
@@ -24,6 +24,7 @@ paths:
         - zCap: []
       operationId: createWorkflow
       description: Creates a new workflow and returns workflowId in the response body.
+      x-expectedCaller: Administrators
       requestBody:
         content:
           application/json:
@@ -53,6 +54,7 @@ paths:
         - zCap: []
       operationId: getWorkflowConfiguration
       description: Gets the configuration of an existing workflow and returns it in the response body.
+      x-expectedCaller: Administrators
       parameters:
         - $ref: "./components/parameters/path/LocalWorkflowId.yml"
       responses:
@@ -79,6 +81,7 @@ paths:
         - zCap: []
       operationId: createExchange
       description: Creates a new exchange and returns exchangeId and time to live in the response body.
+      x-expectedCaller: Owner Coordinator
       parameters:
         - $ref: "./components/parameters/path/LocalWorkflowId.yml"
       requestBody:
@@ -110,6 +113,7 @@ paths:
         - zCap: []
       operationId: getExchangeConfiguration
       description: Gets the configuration of an existing exchange and returns it in the response body.
+      x-expectedCaller: Owner Coordinator
       parameters:
         - $ref: "./components/parameters/path/LocalWorkflowId.yml"
         - $ref: "./components/parameters/path/LocalExchangeId.yml"
@@ -136,6 +140,7 @@ paths:
         - zCap: []
       operationId: participateInExchange
       description: Participate in an exchange. Posting an empty body will start the exchange or return what the exchange is expecting to complete the next step.
+      x-expectedCaller: Anyone
       parameters:
         - $ref: "./components/parameters/path/LocalWorkflowId.yml"
         - $ref: "./components/parameters/path/LocalExchangeId.yml"

--- a/holder.yml
+++ b/holder.yml
@@ -22,7 +22,7 @@ paths:
        - oAuth2: []
        - zCap: []
       summary: Gets a credential or verifiable credential by ID. To get a credential that does not have credential.id set but has an associated credentialId value, pass credentialId instead.
-      servers: [{url: "Issuer Coordinator"}]
+      x-expectedCaller: "Issuer Coordinator"
       operationId: getCredential
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
@@ -57,7 +57,7 @@ paths:
        - oAuth2: []
        - zCap: []
       summary: Deletes a credential or verifiable credential by ID. To delete a credential that does not have credential.id set but has an associated credentialId value, pass credentialId instead.
-      servers: [{url: "Issuer Coordinator"}]
+      x-expectedCaller: "Issuer Coordinator"
       operationId: deleteCredential
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
@@ -86,7 +86,7 @@ paths:
        - zCap: []
       summary: Gets list of credentials or verifiable credentials
       operationId: getCredentials
-      servers: [{url: "Holder Coordinator or Issuer Coordinator"}]
+      x-expectedCaller: "Holder Coordinator or Issuer Coordinator"
       parameters:
         - in: query
           name: type
@@ -128,7 +128,7 @@ paths:
       summary: Derives a credential and returns it in the response body.
       operationId: deriveCredential
       description: Derives a credential and returns it in the response body.
-      servers: [{url: "Holder Coordinator"}]
+      x-expectedCaller: "Holder Coordinator"
       requestBody:
         content:
           application/json:
@@ -159,7 +159,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: getPresentation
-      servers: [{url: "Holder Coordinator"}]
+      x-expectedCaller: "Holder Coordinator"
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
       responses:
@@ -192,7 +192,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: deletePresentation
-      servers: [{url: "Holder Coordinator"}]
+      x-expectedCaller: "Holder Coordinator"
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
       responses:
@@ -220,7 +220,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: getPresentations
-      servers: [{url: "Holder Coordinator"}]
+      x-expectedCaller: "Holder Coordinator"
       parameters:
         - in: query
           name: type
@@ -260,7 +260,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: createPresentation
-      servers: [{url: "Holder Coordinator"}]
+      x-expectedCaller: "Holder Coordinator"
       description: Creates a presentation and returns it in the response body.
       requestBody:
         content:

--- a/holder.yml
+++ b/holder.yml
@@ -22,7 +22,7 @@ paths:
        - oAuth2: []
        - zCap: []
       summary: Gets a credential or verifiable credential by ID. To get a credential that does not have credential.id set but has an associated credentialId value, pass credentialId instead.
-      expectedCaller: Issuer Coordinator
+      servers: [{url: "Issuer Coordinator"}]
       operationId: getCredential
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
@@ -57,7 +57,7 @@ paths:
        - oAuth2: []
        - zCap: []
       summary: Deletes a credential or verifiable credential by ID. To delete a credential that does not have credential.id set but has an associated credentialId value, pass credentialId instead.
-      expectedCaller: Issuer Coordinator
+      servers: [{url: "Issuer Coordinator"}]
       operationId: deleteCredential
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
@@ -86,7 +86,7 @@ paths:
        - zCap: []
       summary: Gets list of credentials or verifiable credentials
       operationId: getCredentials
-      expectedCaller: Holder Coordinator or Issuer Coordinator
+      servers: [{url: "Holder Coordinator or Issuer Coordinator"}]
       parameters:
         - in: query
           name: type
@@ -128,7 +128,7 @@ paths:
       summary: Derives a credential and returns it in the response body.
       operationId: deriveCredential
       description: Derives a credential and returns it in the response body.
-      expectedCaller: Holder Coordinator
+      servers: [{url: "Holder Coordinator"}]
       requestBody:
         content:
           application/json:
@@ -159,7 +159,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: getPresentation
-      expectedCaller: Holder Coordinator
+      servers: [{url: "Holder Coordinator"}]
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
       responses:
@@ -192,7 +192,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: deletePresentation
-      expectedCaller: Holder Coordinator
+      servers: [{url: "Holder Coordinator"}]
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
       responses:
@@ -220,7 +220,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: getPresentations
-      expectedCaller: Holder Coordinator
+      servers: [{url: "Holder Coordinator"}]
       parameters:
         - in: query
           name: type
@@ -260,7 +260,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: createPresentation
-      expectedCaller: Holder Coordinator
+      servers: [{url: "Holder Coordinator"}]
       description: Creates a presentation and returns it in the response body.
       requestBody:
         content:

--- a/holder.yml
+++ b/holder.yml
@@ -22,6 +22,7 @@ paths:
        - oAuth2: []
        - zCap: []
       summary: Gets a credential or verifiable credential by ID. To get a credential that does not have credential.id set but has an associated credentialId value, pass credentialId instead.
+      expectedCaller: Issuer Coordinator
       operationId: getCredential
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
@@ -56,6 +57,7 @@ paths:
        - oAuth2: []
        - zCap: []
       summary: Deletes a credential or verifiable credential by ID. To delete a credential that does not have credential.id set but has an associated credentialId value, pass credentialId instead.
+      expectedCaller: Issuer Coordinator
       operationId: deleteCredential
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
@@ -84,6 +86,7 @@ paths:
        - zCap: []
       summary: Gets list of credentials or verifiable credentials
       operationId: getCredentials
+      expectedCaller: Holder Coordinator or Issuer Coordinator
       parameters:
         - in: query
           name: type
@@ -125,6 +128,7 @@ paths:
       summary: Derives a credential and returns it in the response body.
       operationId: deriveCredential
       description: Derives a credential and returns it in the response body.
+      expectedCaller: Holder Coordinator
       requestBody:
         content:
           application/json:
@@ -155,6 +159,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: getPresentation
+      expectedCaller: Holder Coordinator
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
       responses:
@@ -187,6 +192,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: deletePresentation
+      expectedCaller: Holder Coordinator
       parameters:
         - $ref: "./components/parameters/path/ObjectId.yml"
       responses:
@@ -214,6 +220,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: getPresentations
+      expectedCaller: Holder Coordinator
       parameters:
         - in: query
           name: type
@@ -253,6 +260,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: createPresentation
+      expectedCaller: Holder Coordinator
       description: Creates a presentation and returns it in the response body.
       requestBody:
         content:

--- a/index.html
+++ b/index.html
@@ -689,7 +689,8 @@ All entity bodies in requests and responses sent to or received from the API end
     <section>
       <h3>API Component Overview</h3>
         <p>
-          This section gives an overview of all endpoints in the VC-API by the component the endpoint is expected to be called from. If a component is does not have a listing below it means the VC-API does not currently specify any endpoints for that component. 
+          This section gives an overview of all endpoints in the VC-API by the component the endpoint is expected be callable from. 
+          If a component does not have a listing below it means the VC-API does not currently specify any endpoints for that component. 
         </p>
 
       <h4>Issuer Coordinator</h4>

--- a/index.html
+++ b/index.html
@@ -697,7 +697,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Issuer Coordinator, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="api-compenent-table"
+      <table class="simple api-compenent-table"
         data-api-path="/credentials"></table>
       
       <h4>Issuer Service</h4>
@@ -705,7 +705,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Issuer Service, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="api-compenent-table"
+      <table class="simple api-compenent-table"
         data-api-path="/credentials/issue /credentials /credentials/{id}"></table>
       
       <h4>Status Service</h4>
@@ -713,7 +713,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Status Service, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="api-compenent-table"
+      <table class="simple api-compenent-table"
         data-api-path="/credentials/status"></table>
       
       <h4>Verification Service</h4>
@@ -721,7 +721,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Verification Service, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="api-compenent-table"
+      <table class="simple api-compenent-table"
         data-api-path="/credentials/verify /presentations/verify /challenges"></table>
       
       <h4>Holder Service</h4>
@@ -729,7 +729,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Holder Service, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="api-compenent-table"
+      <table class="simple api-compenent-table"
         data-api-path="/credentials/derive /presentations/prove /presentations /presentations/{id}"></table>
       
       <h4>Workflow Service</h4>
@@ -737,7 +737,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Workflow Service, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="api-compenent-table"
+      <table class="simple api-compenent-table"
         data-api-path=""></table>
       
     </section>

--- a/index.html
+++ b/index.html
@@ -739,7 +739,7 @@ All entity bodies in requests and responses sent to or received from the API end
         that is expected to call the endpoint
       </p>
       <table class="simple api-component-table"
-        data-api-path=""></table>
+        data-api-path="/exchanges"></table>
       
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -739,7 +739,7 @@ All entity bodies in requests and responses sent to or received from the API end
         that is expected to call the endpoint
       </p>
       <table class="simple api-component-table"
-        data-api-path="/exchanges"></table>
+        data-api-path="/workflows /workflows/{localWorkflowId} /workflows/{localWorkflowId}/exchanges /workflows/{localWorkflowId}/exchanges/{localExchangeId}"></table>
       
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -693,26 +693,50 @@ All entity bodies in requests and responses sent to or received from the API end
         </p>
 
       <h4>Issuer Coordinator</h4>
+      <p>
+        Below are all endpoints expected to be exposed by the Issuer Coordinator, along with the component
+        that is expected to call the endpoint
+      </p>
       <table class="api-compenent-table"
         data-api-path="/credentials"></table>
       
       <h4>Issuer Service</h4>
+      <p>
+        Below are all endpoints expected to be exposed by the Issuer Service, along with the component
+        that is expected to call the endpoint
+      </p>
       <table class="api-compenent-table"
         data-api-path="/credentials/issue /credentials /credentials/{id}"></table>
       
       <h4>Status Service</h4>
+      <p>
+        Below are all endpoints expected to be exposed by the Status Service, along with the component
+        that is expected to call the endpoint
+      </p>
       <table class="api-compenent-table"
         data-api-path="/credentials/status"></table>
       
       <h4>Verification Service</h4>
+      <p>
+        Below are all endpoints expected to be exposed by the Verification Service, along with the component
+        that is expected to call the endpoint
+      </p>
       <table class="api-compenent-table"
         data-api-path="/credentials/verify /presentations/verify /challenges"></table>
       
       <h4>Holder Service</h4>
+      <p>
+        Below are all endpoints expected to be exposed by the Holder Service, along with the component
+        that is expected to call the endpoint
+      </p>
       <table class="api-compenent-table"
         data-api-path="/credentials/derive /presentations/prove /presentations /presentations/{id}"></table>
       
       <h4>Workflow Service</h4>
+      <p>
+        Below are all endpoints expected to be exposed by the Workflow Service, along with the component
+        that is expected to call the endpoint
+      </p>
       <table class="api-compenent-table"
         data-api-path=""></table>
       

--- a/index.html
+++ b/index.html
@@ -689,7 +689,7 @@ All entity bodies in requests and responses sent to or received from the API end
     <section>
       <h3>API Component Overview</h3>
         <p>
-          This section gives an overview of all endpoints in the VC-API by the component the endpoint is expected to be called from. If a compenent is does not have a listing below it means the VC-API does not currently specify any endpoints for that compenent. 
+          This section gives an overview of all endpoints in the VC-API by the component the endpoint is expected to be called from. If a component is does not have a listing below it means the VC-API does not currently specify any endpoints for that component. 
         </p>
 
       <h4>Issuer Coordinator</h4>
@@ -697,7 +697,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Issuer Coordinator, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="simple api-compenent-table"
+      <table class="simple api-component-table"
         data-api-path="/credentials"></table>
       
       <h4>Issuer Service</h4>
@@ -705,7 +705,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Issuer Service, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="simple api-compenent-table"
+      <table class="simple api-component-table"
         data-api-path="/credentials/issue /credentials /credentials/{id}"></table>
       
       <h4>Status Service</h4>
@@ -713,7 +713,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Status Service, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="simple api-compenent-table"
+      <table class="simple api-component-table"
         data-api-path="/credentials/status"></table>
       
       <h4>Verification Service</h4>
@@ -721,7 +721,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Verification Service, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="simple api-compenent-table"
+      <table class="simple api-component-table"
         data-api-path="/credentials/verify /presentations/verify /challenges"></table>
       
       <h4>Holder Service</h4>
@@ -729,7 +729,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Holder Service, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="simple api-compenent-table"
+      <table class="simple api-component-table"
         data-api-path="/credentials/derive /presentations/prove /presentations /presentations/{id}"></table>
       
       <h4>Workflow Service</h4>
@@ -737,7 +737,7 @@ All entity bodies in requests and responses sent to or received from the API end
         Below are all endpoints expected to be exposed by the Workflow Service, along with the component
         that is expected to call the endpoint
       </p>
-      <table class="simple api-compenent-table"
+      <table class="simple api-component-table"
         data-api-path=""></table>
       
     </section>

--- a/index.html
+++ b/index.html
@@ -687,6 +687,37 @@ All entity bodies in requests and responses sent to or received from the API end
     </section>
 
     <section>
+      <h3>API Component Overview</h3>
+        <p>
+          This section gives an overview of all endpoints in the VC-API by the component the endpoint is expected to be called from. If a compenent is does not have a listing below it means the VC-API does not currently specify any endpoints for that compenent. 
+        </p>
+
+      <h4>Issuer Coordinator</h4>
+      <table class="api-compenent-table"
+        data-api-path="/credentials"></table>
+      
+      <h4>Issuer Service</h4>
+      <table class="api-compenent-table"
+        data-api-path="/credentials/issue /credentials /credentials/{id}"></table>
+      
+      <h4>Status Service</h4>
+      <table class="api-compenent-table"
+        data-api-path="/credentials/status"></table>
+      
+      <h4>Verification Service</h4>
+      <table class="api-compenent-table"
+        data-api-path="/credentials/verify /presentations/verify /challenges"></table>
+      
+      <h4>Holder Service</h4>
+      <table class="api-compenent-table"
+        data-api-path="/credentials/derive /presentations/prove /presentations /presentations/{id}"></table>
+      
+      <h4>Workflow Service</h4>
+      <table class="api-compenent-table"
+        data-api-path=""></table>
+      
+    </section>
+    <section>
       <h3>Issuing</h3>
       <p>
 The following APIs are defined for issuing a Verifiable Credential:

--- a/issuer.yml
+++ b/issuer.yml
@@ -23,6 +23,7 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: issueCredential
+      expectedCaller: Issuer Coordinator
       description: Issues a credential and returns it in the response body.
       requestBody:
         content:
@@ -54,6 +55,7 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: updateCredentialStatus
+      expectedCaller: Verifier Service
       description: Updates the status of an issued credential.
       requestBody:
         content:

--- a/issuer.yml
+++ b/issuer.yml
@@ -23,7 +23,7 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: issueCredential
-      servers: [{url: "Issuer Coordinator"}]
+      x-expectedCaller: "Issuer Coordinator"
       description: Issues a credential and returns it in the response body.
       requestBody:
         content:
@@ -55,7 +55,7 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: updateCredentialStatus
-      servers: [{url: "Verifier Service"}]
+      x-expectedCaller: "Verifier Service"
       description: Updates the status of an issued credential.
       requestBody:
         content:

--- a/issuer.yml
+++ b/issuer.yml
@@ -13,7 +13,6 @@ info:
     name: GitHub Source Code
     url: https://github.com/w3c-ccg/vc-api
 paths:
-  expectedCaller: Issuer Coordinator
   /credentials/issue:
     post:
       summary: Issues a credential and returns it in the response body.
@@ -24,6 +23,7 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: issueCredential
+      servers: [{url: "Issuer Coordinator"}]
       description: Issues a credential and returns it in the response body.
       requestBody:
         content:
@@ -55,7 +55,7 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: updateCredentialStatus
-      expectedCaller: Verifier Service
+      servers: [{url: "Verifier Service"}]
       description: Updates the status of an issued credential.
       requestBody:
         content:

--- a/issuer.yml
+++ b/issuer.yml
@@ -13,6 +13,7 @@ info:
     name: GitHub Source Code
     url: https://github.com/w3c-ccg/vc-api
 paths:
+  expectedCaller: Issuer Coordinator
   /credentials/issue:
     post:
       summary: Issues a credential and returns it in the response body.
@@ -23,7 +24,6 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: issueCredential
-      expectedCaller: Issuer Coordinator
       description: Issues a credential and returns it in the response body.
       requestBody:
         content:

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -29,7 +29,7 @@ function buildComponentTables({config, document, apis}) {
       if(path.trim().length > 0) {
         const endpoint = getEndpoint({apis, path});
         for(const verb in endpoint) {
-          var expectedCaller = endpoint['x-expectedCaller'];
+          const expectedCaller = endpoint[verb]['x-expectedCaller'];
           const tableRow = document.createElement('tr');
           if(expectedCaller === undefined)
           {

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -29,10 +29,10 @@ function buildComponentTables({config, document, apis}) {
       if(path.trim().length > 0) {
         const endpoint = getEndpoint({apis, path});
         for(const verb in endpoint) {
-          const {expectedCaller} = endpoint[verb];
+          const {servers} = endpoint[verb];
           const tableRow = document.createElement('tr');
           tableRow.innerHTML =
-            `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${expectedCaller}</td>`;
+            `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${servers[0]}</td>`;
           table.appendChild(tableRow);
         }
       }

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -28,7 +28,7 @@ function buildComponentTables({config, document, apis}) {
     for(const path of table.dataset.apiPath.split(/\s+/)) {
       if(path.trim().length > 0) {
         const endpoint = getEndpoint({apis, path});
-        const expectedCaller = endpoint['x-expectedCaller'];
+        var expectedCaller = endpoint['x-expectedCaller'];
         const tableRow = document.createElement('tr');
         if(expectedCaller === undefined)
         {

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -31,7 +31,6 @@ function buildComponentTables({config, document, apis}) {
         for(const verb in endpoint) {
           const {servers} = endpoint[verb];
           const tableRow = document.createElement('tr');
-          const expectedCaller = ${servers[0].url};
           tableRow.innerHTML =
             `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${servers[0].url}</td>`;
           table.appendChild(tableRow);

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -31,7 +31,7 @@ function buildComponentTables({config, document, apis}) {
         for(const verb in endpoint) {
           const {servers} = endpoint[verb];
           const tableRow = document.createElement('tr');
-          const expectedCaller = ${servers[0].url}
+          const expectedCaller = ${servers[0].url};
           tableRow.innerHTML =
             `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${servers[0].url}</td>`;
           table.appendChild(tableRow);

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -31,6 +31,7 @@ function buildComponentTables({config, document, apis}) {
         for(const verb in endpoint) {
           const {servers} = endpoint[verb];
           const tableRow = document.createElement('tr');
+          const expectedCaller = ${servers[0].url}
           tableRow.innerHTML =
             `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${servers[0].url}</td>`;
           table.appendChild(tableRow);

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -364,8 +364,8 @@ async function injectOas(config, document) {
     const apis = [issuerApi, verifierApi, holderApi];
 
     buildApiSummaryTables({config, document, apis});
-    buildComponentTables({config, document, apis});
     buildEndpointDetails({config, document, apis});
+    buildComponentTables({config, document, apis});
   } catch(err) {
     console.error(err);
   }

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -366,7 +366,7 @@ async function injectOas(config, document) {
 
     buildApiSummaryTables({config, document, apis});
     buildEndpointDetails({config, document, apis});
-    buildApiSummaryTables({config, document, apis});
+    buildComponentTables({config, document, apis});
   } catch(err) {
     console.error(err);
   }

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -28,15 +28,17 @@ function buildComponentTables({config, document, apis}) {
     for(const path of table.dataset.apiPath.split(/\s+/)) {
       if(path.trim().length > 0) {
         const endpoint = getEndpoint({apis, path});
-        var expectedCaller = endpoint['x-expectedCaller'];
-        const tableRow = document.createElement('tr');
-        if(expectedCaller === undefined)
-        {
-          expectedCaller = "Expected Caller Undefined";;
+        for(const verb in endpoint) {
+          var expectedCaller = endpoint['x-expectedCaller'];
+          const tableRow = document.createElement('tr');
+          if(expectedCaller === undefined)
+          {
+            expectedCaller = "Expected Caller Undefined";;
+          }
+          tableRow.innerHTML =
+            `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${expectedCaller}</td>`;
+          table.appendChild(tableRow);
         }
-        tableRow.innerHTML =
-          `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${expectedCaller}</td>`;
-        table.appendChild(tableRow);
       }
     }
   }

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -363,9 +363,9 @@ async function injectOas(config, document) {
       holderApi.info.title, holderApi.info.version);
     const apis = [issuerApi, verifierApi, holderApi];
 
-    //buildApiSummaryTables({config, document, apis});
-    //buildEndpointDetails({config, document, apis});
-    //buildApiSummaryTables({config, document, apis});
+    buildApiSummaryTables({config, document, apis});
+    buildEndpointDetails({config, document, apis});
+    buildApiSummaryTables({config, document, apis});
   } catch(err) {
     console.error(err);
   }

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -28,18 +28,15 @@ function buildComponentTables({config, document, apis}) {
     for(const path of table.dataset.apiPath.split(/\s+/)) {
       if(path.trim().length > 0) {
         const endpoint = getEndpoint({apis, path});
-        for(const verb in endpoint) {
-          const {servers} = endpoint[verb];
-          const tableRow = document.createElement('tr');
-          var expectedCaller = "Expected Caller Undefined";
-          if(servers !== undefined)
-          {
-            expectedCaller = servers[0].url;
-          }
-          tableRow.innerHTML =
-            `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${expectedCaller}</td>`;
-          table.appendChild(tableRow);
+        const expectedCaller = endpoint['x-expectedCaller'];
+        const tableRow = document.createElement('tr');
+        if(expectedCaller === undefined)
+        {
+          expectedCaller = "Expected Caller Undefined";;
         }
+        tableRow.innerHTML =
+          `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${expectedCaller}</td>`;
+        table.appendChild(tableRow);
       }
     }
   }

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -19,7 +19,7 @@ function buildComponentTables({config, document, apis}) {
 
   // process every table
   for(const table of apiTables) {
-    // set up the API summary table headers
+    // set up the API component table headers
     const tableHeader = document.createElement('tr');
     tableHeader.innerHTML = '<th>Endpoint</th><th>Expected Caller</th>';
     table.appendChild(tableHeader);
@@ -31,6 +31,7 @@ function buildComponentTables({config, document, apis}) {
         for(const verb in endpoint) {
           const {servers} = endpoint[verb];
           const tableRow = document.createElement('tr');
+          console.log("servers: %s", {servers[0]});
           tableRow.innerHTML =
             `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${servers[0]}</td>`;
           table.appendChild(tableRow);

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -31,8 +31,13 @@ function buildComponentTables({config, document, apis}) {
         for(const verb in endpoint) {
           const {servers} = endpoint[verb];
           const tableRow = document.createElement('tr');
+          var expectedCaller = "";
+          if(servers !== undefined)
+          {
+            expectedCaller = servers[0].url;
+          }
           tableRow.innerHTML =
-            `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${servers[0].url}</td>`;
+            `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${expectedCaller}</td>`;
           table.appendChild(tableRow);
         }
       }

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -364,8 +364,8 @@ async function injectOas(config, document) {
     const apis = [issuerApi, verifierApi, holderApi];
 
     buildApiSummaryTables({config, document, apis});
-    buildEndpointDetails({config, document, apis});
     buildComponentTables({config, document, apis});
+    buildEndpointDetails({config, document, apis});
   } catch(err) {
     console.error(err);
   }

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -14,6 +14,32 @@ function getEndpoint({apis, path}) {
   return endpoint;
 }
 
+function buildComponentTables({config, document, apis}) {
+  const apiTables = document.querySelectorAll("table.api-component-table");
+
+  // process every table
+  for(const table of apiTables) {
+    // set up the API summary table headers
+    const tableHeader = document.createElement('tr');
+    tableHeader.innerHTML = '<th>Endpoint</th><th>Expected Caller</th>';
+    table.appendChild(tableHeader);
+
+    // summarize each API endpoint
+    for(const path of table.dataset.apiPath.split(/\s+/)) {
+      if(path.trim().length > 0) {
+        const endpoint = getEndpoint({apis, path});
+        for(const verb in endpoint) {
+          const {expectedCaller} = endpoint[verb];
+          const tableRow = document.createElement('tr');
+          tableRow.innerHTML =
+            `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${expectedCaller}</td>`;
+          table.appendChild(tableRow);
+        }
+      }
+    }
+  }
+}
+
 function buildApiSummaryTables({config, document, apis}) {
   const apiTables = document.querySelectorAll("table.api-summary-table");
 
@@ -339,6 +365,7 @@ async function injectOas(config, document) {
 
     buildApiSummaryTables({config, document, apis});
     buildEndpointDetails({config, document, apis});
+    buildApiSummaryTables({config, document, apis});
   } catch(err) {
     console.error(err);
   }

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -355,17 +355,17 @@ async function injectOas(config, document) {
     const issuerApi = await SwaggerParser.validate('issuer.yml');
     console.log('API name: %s, Version: %s',
       issuerApi.info.title, issuerApi.info.version);
-    const verifierApi = await SwaggerParser.validate('verifier.yml');
+    //const verifierApi = await SwaggerParser.validate('verifier.yml');
     console.log('API name: %s, Version: %s',
       verifierApi.info.title, verifierApi.info.version);
-    const holderApi = await SwaggerParser.validate('holder.yml');
+    //const holderApi = await SwaggerParser.validate('holder.yml');
     console.log('API name: %s, Version: %s',
       holderApi.info.title, holderApi.info.version);
-    const apis = [issuerApi, verifierApi, holderApi];
+    //const apis = [issuerApi, verifierApi, holderApi];
 
-    buildApiSummaryTables({config, document, apis});
-    buildEndpointDetails({config, document, apis});
-    buildApiSummaryTables({config, document, apis});
+    //buildApiSummaryTables({config, document, apis});
+    //buildEndpointDetails({config, document, apis});
+    //buildApiSummaryTables({config, document, apis});
   } catch(err) {
     console.error(err);
   }

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -355,13 +355,13 @@ async function injectOas(config, document) {
     const issuerApi = await SwaggerParser.validate('issuer.yml');
     console.log('API name: %s, Version: %s',
       issuerApi.info.title, issuerApi.info.version);
-    //const verifierApi = await SwaggerParser.validate('verifier.yml');
+    const verifierApi = await SwaggerParser.validate('verifier.yml');
     console.log('API name: %s, Version: %s',
       verifierApi.info.title, verifierApi.info.version);
-    //const holderApi = await SwaggerParser.validate('holder.yml');
+    const holderApi = await SwaggerParser.validate('holder.yml');
     console.log('API name: %s, Version: %s',
       holderApi.info.title, holderApi.info.version);
-    //const apis = [issuerApi, verifierApi, holderApi];
+    const apis = [issuerApi, verifierApi, holderApi];
 
     //buildApiSummaryTables({config, document, apis});
     //buildEndpointDetails({config, document, apis});

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -32,7 +32,7 @@ function buildComponentTables({config, document, apis}) {
           const {servers} = endpoint[verb];
           const tableRow = document.createElement('tr');
           tableRow.innerHTML =
-            `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${servers[0]}</td>`;
+            `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${servers[0].url}</td>`;
           table.appendChild(tableRow);
         }
       }

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -31,7 +31,7 @@ function buildComponentTables({config, document, apis}) {
         for(const verb in endpoint) {
           const {servers} = endpoint[verb];
           const tableRow = document.createElement('tr');
-          var expectedCaller = "";
+          var expectedCaller = "Expected Caller Undefined";
           if(servers !== undefined)
           {
             expectedCaller = servers[0].url;

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -31,7 +31,6 @@ function buildComponentTables({config, document, apis}) {
         for(const verb in endpoint) {
           const {servers} = endpoint[verb];
           const tableRow = document.createElement('tr');
-          console.log("servers: %s", {servers[0]});
           tableRow.innerHTML =
             `<td>${verb.toUpperCase()}&nbsp;${path}</td><td>${servers[0]}</td>`;
           table.appendChild(tableRow);

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -29,7 +29,7 @@ function buildComponentTables({config, document, apis}) {
       if(path.trim().length > 0) {
         const endpoint = getEndpoint({apis, path});
         for(const verb in endpoint) {
-          const expectedCaller = endpoint[verb]['x-expectedCaller'];
+          var expectedCaller = endpoint[verb]['x-expectedCaller'];
           const tableRow = document.createElement('tr');
           if(expectedCaller === undefined)
           {

--- a/verifier.yml
+++ b/verifier.yml
@@ -23,6 +23,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: verifyCredential
+      expectedCaller: Verification Coordinator
       description: Verifies a verifiableCredential and returns a verificationResult in the response body.
       requestBody:
         content:
@@ -51,6 +52,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: verifyPresentation
+      expectedCaller: Verification Coordinator
       description: Verifies a verifiablePresentation and returns a verificationResult in the response body.  Given the possibility of denial of service, buffer overflow, or other style attacks, an implementation is permitted to rate limit or restrict requests against this API endpoint to those requests that contain only a single credential with a 413 or 429 error code as appropriate.
       requestBody:
         content:
@@ -83,6 +85,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: challenge
+      expectedCaller: Verification Coordinator
       description: Creates a challenge to be used as `options.challenge` in future requests.
       responses:
         "200":

--- a/verifier.yml
+++ b/verifier.yml
@@ -23,7 +23,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: verifyCredential
-      servers: [{url: "Verification Coordinator"}]
+      x-expectedCaller: "Verification Coordinator"
       description: Verifies a verifiableCredential and returns a verificationResult in the response body.
       requestBody:
         content:
@@ -52,7 +52,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: verifyPresentation
-      servers: [{url: "Verification Coordinator"}]
+      x-expectedCaller: "Verification Coordinator"
       description: Verifies a verifiablePresentation and returns a verificationResult in the response body.  Given the possibility of denial of service, buffer overflow, or other style attacks, an implementation is permitted to rate limit or restrict requests against this API endpoint to those requests that contain only a single credential with a 413 or 429 error code as appropriate.
       requestBody:
         content:
@@ -85,7 +85,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: challenge
-      servers: [{url: "Verification Coordinator"}]
+      x-expectedCaller: "Verification Coordinator"
       description: Creates a challenge to be used as `options.challenge` in future requests.
       responses:
         "200":

--- a/verifier.yml
+++ b/verifier.yml
@@ -23,7 +23,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: verifyCredential
-      expectedCaller: Verification Coordinator
+      servers: [{url: "Verification Coordinator"}]
       description: Verifies a verifiableCredential and returns a verificationResult in the response body.
       requestBody:
         content:
@@ -52,7 +52,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: verifyPresentation
-      expectedCaller: Verification Coordinator
+      servers: [{url: "Verification Coordinator"}]
       description: Verifies a verifiablePresentation and returns a verificationResult in the response body.  Given the possibility of denial of service, buffer overflow, or other style attacks, an implementation is permitted to rate limit or restrict requests against this API endpoint to those requests that contain only a single credential with a 413 or 429 error code as appropriate.
       requestBody:
         content:
@@ -85,7 +85,7 @@ paths:
        - oAuth2: []
        - zCap: []
       operationId: challenge
-      expectedCaller: Verification Coordinator
+      servers: [{url: "Verification Coordinator"}]
       description: Creates a challenge to be used as `options.challenge` in future requests.
       responses:
         "200":

--- a/versions/v0.0.2/vc-api.yml
+++ b/versions/v0.0.2/vc-api.yml
@@ -23,7 +23,7 @@ paths:
         - Issuer
       summary: Issues a credential and returns it in the response body.
       operationId: issueCredential
-      servers: [{url:"Issuer Coordinator"}]
+      x-expectedCaller: "Issuer Coordinator"
       description: Issues a credential and returns it in the response body.
       requestBody:
         content:
@@ -48,7 +48,7 @@ paths:
         - Holder
       summary: Derives a credential and returns it in the response body.
       operationId: deriveCredential
-      servers: [{url:"Holder Coordinator"}]
+      x-expectedCaller: "Holder Coordinator"
       description: Derives a credential and returns it in the response body.
       requestBody:
         content:
@@ -75,7 +75,7 @@ paths:
         - Issuer
       summary: Updates the status of an issued credential
       operationId: updateCredentialStatus
-      servers: [{url:"Status Service"}]
+      x-expectedCaller: "Status Service"
       description: Updates the status of an issued credential.
       requestBody:
         content:
@@ -98,7 +98,7 @@ paths:
         - Holder
       summary: Proves a presentation and returns it in the response body.
       operationId: provePresentation
-      servers: [{url:"Holder Coordinator"}]
+      x-expectedCaller: "Holder Coordinator"
       description: Proves a presentation and returns it in the response body.
       requestBody:
         content:
@@ -123,7 +123,7 @@ paths:
         - Verifier
       summary: Verifies a verifiableCredential and returns a verificationResult in the response body.
       operationId: verifyCredential
-      servers: [{url:"Verification Coordinator"}]
+      x-expectedCaller: "Verification Coordinator"
       description: Verifies a verifiableCredential and returns a verificationResult in the response body.
       requestBody:
         content:
@@ -148,7 +148,7 @@ paths:
         - Verifier
       summary: Verifies a Presentation with or without proofs attached and returns a verificationResult in the response body.
       operationId: verifyPresentation
-      servers: [{url:"Verification Coordinator"}]
+      x-expectedCaller: "Verification Coordinator"
       description: Verifies a verifiablePresentation and returns a verificationResult in the response body.  Given the possibility of denial of service, buffer overflow, or other style attacks, an implementation is permitted to rate limit or restrict requests against this API endpoint to those requests that contain only a single credential with a 413 or 429 error code as appropriate.
       requestBody:
         content:

--- a/versions/v0.0.2/vc-api.yml
+++ b/versions/v0.0.2/vc-api.yml
@@ -23,6 +23,7 @@ paths:
         - Issuer
       summary: Issues a credential and returns it in the response body.
       operationId: issueCredential
+      servers: [{url:"Issuer Coordinator"}]
       description: Issues a credential and returns it in the response body.
       requestBody:
         content:
@@ -47,6 +48,7 @@ paths:
         - Holder
       summary: Derives a credential and returns it in the response body.
       operationId: deriveCredential
+      servers: [{url:"Holder Coordinator"}]
       description: Derives a credential and returns it in the response body.
       requestBody:
         content:
@@ -73,6 +75,7 @@ paths:
         - Issuer
       summary: Updates the status of an issued credential
       operationId: updateCredentialStatus
+      servers: [{url:"Status Service"}]
       description: Updates the status of an issued credential.
       requestBody:
         content:
@@ -95,6 +98,7 @@ paths:
         - Holder
       summary: Proves a presentation and returns it in the response body.
       operationId: provePresentation
+      servers: [{url:"Holder Coordinator"}]
       description: Proves a presentation and returns it in the response body.
       requestBody:
         content:
@@ -119,6 +123,7 @@ paths:
         - Verifier
       summary: Verifies a verifiableCredential and returns a verificationResult in the response body.
       operationId: verifyCredential
+      servers: [{url:"Verification Coordinator"}]
       description: Verifies a verifiableCredential and returns a verificationResult in the response body.
       requestBody:
         content:
@@ -143,6 +148,7 @@ paths:
         - Verifier
       summary: Verifies a Presentation with or without proofs attached and returns a verificationResult in the response body.
       operationId: verifyPresentation
+      servers: [{url:"Verification Coordinator"}]
       description: Verifies a verifiablePresentation and returns a verificationResult in the response body.  Given the possibility of denial of service, buffer overflow, or other style attacks, an implementation is permitted to rate limit or restrict requests against this API endpoint to those requests that contain only a single credential with a 413 or 429 error code as appropriate.
       requestBody:
         content:


### PR DESCRIPTION
This PR looks to resolve https://github.com/w3c-ccg/vc-api/issues/285 

A section has been added to the "The VC API " section of the document called "API Component Overview". This section summarizes all endpoints in the VC-API, grouping them by the component the endpoint is expected to live on, along with a table for each of these components that lists the API endpoint, as well as the component that is the expected caller of the endpoint. 

The workflow/exchanges endpoints are not currently indexed but should be added after the following PR is completed:
https://github.com/w3c-ccg/vc-api/pull/382


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eric-schuh/vc-api/pull/384.html" title="Last updated on Jun 4, 2024, 5:16 PM UTC (d67e052)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/384/c02e73f...eric-schuh:d67e052.html" title="Last updated on Jun 4, 2024, 5:16 PM UTC (d67e052)">Diff</a>