### PR TITLE
Add error handling section

### DIFF
--- a/holder.yml
+++ b/holder.yml
@@ -44,10 +44,6 @@ paths:
           description: Gone! There is no data here
         "418":
           description: I'm a teapot - MUST not be returned outside of pre-arranged scenarios between both parties
-        "500":
-          description: Internal Error
-        "501":
-          description: Not Implemented
     delete:
       tags:
        - Credentials
@@ -70,10 +66,6 @@ paths:
           description: Credential not found
         "410":
           description: Gone! There is no data here
-        "500":
-          description: Internal Error
-        "501":
-          description: Not Implemented
   /credentials:
     get:
       tags:
@@ -110,10 +102,6 @@ paths:
           description: Not Authorized
         "410":
           description: Gone! There is no data here
-        "500":
-          description: Internal Error
-        "501":
-          description: Not Implemented
   /credentials/derive:
     post:
       tags:
@@ -140,10 +128,6 @@ paths:
                 $ref: "#/components/schemas/DeriveCredentialResponse"
         "400":
           description: Invalid Request
-        "500":
-          description: Internal Error
-        "501":
-          description: Not Implemented
 
   /presentations/{id}:
     get:
@@ -174,10 +158,6 @@ paths:
           description: Presentation not found
         "410":
           description: Gone! There is no data here
-        "500":
-          description: Internal Error
-        "501":
-          description: Not Implemented
     delete:
       tags:
        - Presentations
@@ -200,10 +180,6 @@ paths:
           description: Presentation not found
         "410":
           description: Gone! There is no data here
-        "500":
-          description: Internal Error
-        "501":
-          description: Not Implemented
   /presentations:
     get:
       tags:
@@ -240,10 +216,6 @@ paths:
           description: Not Authorized
         "410":
           description: Gone! There is no data here
-        "500":
-          description: Internal Error
-        "501":
-          description: Not Implemented
     post:
       summary: Creates a presentation and returns it in the response body.
       tags:
@@ -269,8 +241,6 @@ paths:
                 $ref: "#/components/schemas/CreatePresentationResponse"
         "400":
           description: invalid input!
-        "500":
-          description: error!
   /exchanges:
     get:
       summary: Provides a discovery endpoint for the exchanges supported by this server endpoint.
@@ -377,8 +347,6 @@ paths:
                 }
         "400":
           description: invalid input
-        "500" :
-          description: error
 
   /exchanges/{exchange-id}:
     post:
@@ -426,10 +394,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "501":
-          description: Service not implemented.
-        "500":
-          description: Internal server error.
   /exchanges/{exchange-id}/{transaction-id}:
     post:
       summary: Receives information related to an existing exchange.
@@ -472,10 +436,6 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: The associated exchange or transaction was not found.
-        "500":
-          description: Internal server error.
-        "501":
-          description: Service not implemented.
 
 components:
   securitySchemes:

--- a/index.html
+++ b/index.html
@@ -1186,25 +1186,27 @@ Connection: keep-alive
         when identifying technical friction impacting interoperability.
       </p>
       </p>
-        Other fields such as [detail](https://www.rfc-editor.org/rfc/rfc9457.html#name-detail), 
-        [instance](https://www.rfc-editor.org/rfc/rfc9457.html#name-instance) 
+        Leveraging other fields such as [detail](https://www.rfc-editor.org/rfc/rfc9457.html#name-detail), 
+        [instance](https://www.rfc-editor.org/rfc/rfc9457.html#name-instance),
         and [type](https://www.rfc-editor.org/rfc/rfc9457.html#name-type) 
-        are encouraged to be leveraged to provide more contextual feedback about the error, 
-        while being conscious of not disclosing sensitive information for security concerns.
+        is encouraged, to provide more contextual feedback about the error, 
+        while being conscious of security concerns and hence not disclosing
+        sensitive information.
       </p>
       <p>
-        Implementers should try to handle all server errors in the best of their capabilities. 
-        Endpoints should avoid returning improperly handled 500 errors in a production 
-        environment leading to potential [information disclosure](https://owasp.org/www-community/Improper_Error_Handling).
+        Implementers should handle all server errors to the best of their capabilities. 
+        Endpoints should avoid returning improperly handled 500 errors in production 
+        environments, as these may lead to [information disclosure](https://owasp.org/www-community/Improper_Error_Handling).
       </p>
       <h4>Relationship between verification and error handling</h4>
       <p>
-        While performing [verification](https://w3c.github.io/vc-data-model/#verification), 
-        an implementer should avoid raising errors and instead gather 
+        An implementer should avoid raising errors while performing
+        [verification](https://w3c.github.io/vc-data-model/#verification), 
+        and instead should gather 
         [ProblemDetails](https://w3c.github.io/vc-data-model/#problem-details) 
         objects to include in the verification results.
       </p>
-      <h4>ProblemDetails Types</h4>
+      <h4>Types of ProblemDetails</h4>
         <h5>[PARSING_ERROR](https://www.w3.org/TR/vc-data-model#PARSING_ERROR)</h5>
         <h5>[STATUS_NOT_UPDATED_ERROR](https://www.w3.org/TR/vc-data-model#STATUS_NOT_UPDATED_ERROR)</h5>
         <h5>[CRYPTOGRAPHIC_SECURITY_ERROR](https://www.w3.org/TR/vc-data-model#CRYPTOGRAPHIC_SECURITY_ERROR)</h5>

--- a/index.html
+++ b/index.html
@@ -1176,41 +1176,56 @@ Connection: keep-alive
     <section>
       <h3>Error Handling</h3>
       <p>
-        Error handling and messaging in the vc-api is designed in accordance with [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html). 
-        Implementers SHOULD include a [status](https://www.rfc-editor.org/rfc/rfc9457.html#name-status) and a [title](https://www.rfc-editor.org/rfc/rfc9457.html#name-title) 
-        in the error response in accordance with the specifics of the endpoints on which the error occurs. 
-        Other fields such as [detail](https://www.rfc-editor.org/rfc/rfc9457.html#name-detail), [instance](https://www.rfc-editor.org/rfc/rfc9457.html#name-instance) and 
-        [type](https://www.rfc-editor.org/rfc/rfc9457.html#name-type) are encouraged to be leveraged to provide more contextual feedback about the error, 
+        Error handling and messaging in the VC-API follows [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html). 
+        Implementers SHOULD include a [status](https://www.rfc-editor.org/rfc/rfc9457.html#name-status) 
+        and a [title](https://www.rfc-editor.org/rfc/rfc9457.html#name-title) 
+        in the error response body relating to the specifics of the endpoint on which the error occurs. 
+      <p>
+      <p>
+        Aligning on error handling and messaging will greatly improve test-suites accuracy 
+        when identifying interoperability technical friction.
+      </p>
+      </p>
+        Other fields such as [detail](https://www.rfc-editor.org/rfc/rfc9457.html#name-detail), 
+        [instance](https://www.rfc-editor.org/rfc/rfc9457.html#name-instance) 
+        and [type](https://www.rfc-editor.org/rfc/rfc9457.html#name-type) 
+        are encouraged to be leveraged to provide more contextual feedback about the error, 
         while being conscious of not disclosing sensitive information for security concerns.
       </p>
       <p>
-        Implementers SHOULD catch all server errors in the best of their capabilities. 
-        Endpoints should avoid returning improperly handled 500 errors in a production environment leading to potential [information disclosure](https://owasp.org/www-community/Improper_Error_Handling).
+        Implementers should try to handle all server errors in the best of their capabilities. 
+        Endpoints should avoid returning improperly handled 500 errors in a production 
+        environment leading to potential [information disclosure](https://owasp.org/www-community/Improper_Error_Handling).
       </p>
-      <h4>Relationship between verification and error codes</h4>
+      <h4>Relationship between verification and error handling</h4>
       <p>
-        While performing verification of a credential and/or presentation, an implementer might be in a situation where they must raise an error.
-        This is an ambigous case between http protocol related errors and VC specification related errors. 
-        Given a verifiableCredential:
-        For cases where the data model is wrong or the proof is invalid, a 400 invalid input should be returned.
-        For cases where the a verificaiton method cannot be resolved, a 404 missing ressource should be returned.
-        For cases where the validity is bad or the status is invalid, a 422 unprocessable entity should be returned, 
-        meaning the verifier has no intention to process the credential further.
-
-        The logic is to differentiate between a verifier's verification processes and validation processes.
-        
-        As thus, the following mapping of status and title should be applied:
-        - For data model errors, return 400: Data Model
-        - For malformed proof, return 400: Proof Malformed
-        - For invalid proof, return 422: Proof Invalid
-        - For invalid credential/presentation, return 422: Validity Period
-        - For failed status checks, return 422: Status Invalid
+        While performing [verification](https://w3c.github.io/vc-data-model/#verification), 
+        an implementer should avoid raising errors and instead gather 
+        [ProblemDetails](https://w3c.github.io/vc-data-model/#problem-details) 
+        objects to include in the verification results.
       </p>
-      <h4>References</h4>
-      <ul>
-        <li>[OWASP cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Error_Handling_Cheat_Sheet.html) on error handling</li>
-
-      </ul>
+      <h4>ProblemDetails Types</h4>
+        <h5>[PARSING_ERROR](https://www.w3.org/TR/vc-data-model#PARSING_ERROR)</h5>
+        <h5>[STATUS_NOT_UPDATED_ERROR](https://www.w3.org/TR/vc-data-model#STATUS_NOT_UPDATED_ERROR)</h5>
+        <h5>[CRYPTOGRAPHIC_SECURITY_ERROR](https://www.w3.org/TR/vc-data-model#CRYPTOGRAPHIC_SECURITY_ERROR)</h5>
+        <h5>[MALFORMED_VALUE_ERROR](https://www.w3.org/TR/vc-data-model#MALFORMED_VALUE_ERROR)</h5>
+        <h5>[RANGE_ERROR](https://www.w3.org/TR/vc-data-model#RANGE_ERROR)</h5>
+        <h5>[UNRESOLVABLE_DID_ERROR](https://www.w3.org/TR/vc-data-model#UNRESOLVABLE_DID_ERROR)</h5>
+        <h5>[STATUS_WARNING](https://www.w3.org/TR/vc-data-model#STATUS_WARNING)</h5>
+        <h5>[VALIDITY_PERIOD_WARNING](https://www.w3.org/TR/vc-data-model#VALIDITY_PERIOD_WARNING)</h5>
+        <h5>[CONTROLLER_MISMATCH_WARNING](https://www.w3.org/TR/vc-data-model#CONTROLLER_MISMATCH_WARNING)</h5> #141
+      <h4>Verification Response</h4>
+      <code>
+        {
+          "verified": false,
+          "document": {},
+          "mediaType": "",
+          "controller": "",
+          "controllerDocument": {},
+          "warnings": [ProblemDetails],
+          "errors": [ProblemDetails]
+        }
+    </code>
     </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@ Connection: keep-alive
           {
             "verified": false,
             "document": verifiableCredential,
-            "mediaType": "vc+json+ld",
+            "mediaType": "application/vc",
             "controller": issuer,
             "controllerDocument": didDocument,
             "warnings": [ProblemDetails],

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Connection: keep-alive
       <p>
       <p>
         Aligning on error handling and messaging will greatly improve test-suites accuracy 
-        when identifying interoperability technical friction.
+        when identifying technical friction impacting interoperability.
       </p>
       </p>
         Other fields such as [detail](https://www.rfc-editor.org/rfc/rfc9457.html#name-detail), 

--- a/index.html
+++ b/index.html
@@ -1207,27 +1207,37 @@ Connection: keep-alive
         objects to include in the verification results.
       </p>
       <h4>Types of ProblemDetails</h4>
-        <h5>[PARSING_ERROR](https://www.w3.org/TR/vc-data-model#PARSING_ERROR)</h5>
-        <h5>[STATUS_NOT_UPDATED_ERROR](https://www.w3.org/TR/vc-data-model#STATUS_NOT_UPDATED_ERROR)</h5>
-        <h5>[CRYPTOGRAPHIC_SECURITY_ERROR](https://www.w3.org/TR/vc-data-model#CRYPTOGRAPHIC_SECURITY_ERROR)</h5>
-        <h5>[MALFORMED_VALUE_ERROR](https://www.w3.org/TR/vc-data-model#MALFORMED_VALUE_ERROR)</h5>
-        <h5>[RANGE_ERROR](https://www.w3.org/TR/vc-data-model#RANGE_ERROR)</h5>
-        <h5>[UNRESOLVABLE_DID_ERROR](https://www.w3.org/TR/vc-data-model#UNRESOLVABLE_DID_ERROR)</h5>
-        <h5>[STATUS_WARNING](https://www.w3.org/TR/vc-data-model#STATUS_WARNING)</h5>
-        <h5>[VALIDITY_PERIOD_WARNING](https://www.w3.org/TR/vc-data-model#VALIDITY_PERIOD_WARNING)</h5>
-        <h5>[CONTROLLER_MISMATCH_WARNING](https://www.w3.org/TR/vc-data-model#CONTROLLER_MISMATCH_WARNING)</h5> #141
+        At the time of writting, ProblemDetails types refer to the [vc data model specification](https://w3c.github.io/vc-data-model/#problem-details)
+        It would be good to include additional types as time goes on.
+        <h5>Example ProblemDetails</h4>
+          <code>
+          {
+            "type": "https://www.w3.org/TR/vc-data-model#CRYPTOGRAPHIC_SECURITY_ERROR",
+            "status": 400,
+            "title": "CRYPTOGRAPHIC_SECURITY_ERROR",
+            "detail": "The cryptographic security mechanism couldn't be verified. This is likely due to a malformed proof or an invalid verificationMethod."
+          }
+          </code>
       <h4>Verification Response</h4>
-      <code>
-        {
-          "verified": false,
-          "document": {},
-          "mediaType": "",
-          "controller": "",
-          "controllerDocument": {},
-          "warnings": [ProblemDetails],
-          "errors": [ProblemDetails]
-        }
-    </code>
+        <h5>Errors and Warnings</h5>
+        Errors are ProblemDetails relating to cryptography, data model and malformed context.
+        Warnings are ProblemDetails relating to statuses and validity periods.
+
+        The VerificationResponse object MUST have the verified value set to false if an error is included.
+        The VerificationResponse object MUST have the verified value set to true if no errors are included.
+
+        <h5>Verification Response Example</h5>
+        <code>
+          {
+            "verified": false,
+            "document": verifiableCredential,
+            "mediaType": "vc+json+ld",
+            "controller": issuer,
+            "controllerDocument": didDocument,
+            "warnings": [ProblemDetails],
+            "errors": [ProblemDetails]
+          }
+        </code>
     </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -1213,11 +1213,11 @@ Connection: keep-alive
         </pre>
       <h4>Verification Response</h4>
         <h5>Errors and Warnings</h5>
-        Errors are ProblemDetails relating to cryptography, data model and malformed context.
-        Warnings are ProblemDetails relating to statuses and validity periods.
+        Errors are `ProblemDetails` relating to cryptography, data model and malformed context.
+        Warnings are `ProblemDetails` relating to statuses and validity periods.
 
-        The VerificationResponse object MUST have the verified value set to false if an error is included.
-        The VerificationResponse object MUST have the verified value set to true if no errors are included.
+        The `VerificationResponse` object MUST have the `verified` value set to `false` if an error is included.
+        The `VerificationResponse` object MUST have the `verified` value set to `true` if no errors are included.
 
         <pre class="example"
           title="Verification Response">

--- a/index.html
+++ b/index.html
@@ -1173,6 +1173,46 @@ Connection: keep-alive
       </section>
     </section>
 
+    <section>
+      <h3>Error Handling</h3>
+      <p>
+        Error handling and messaging in the vc-api is designed in accordance with [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html). 
+        Implementers SHOULD include a [status](https://www.rfc-editor.org/rfc/rfc9457.html#name-status) and a [title](https://www.rfc-editor.org/rfc/rfc9457.html#name-title) 
+        in the error response in accordance with the specifics of the endpoints on which the error occurs. 
+        Other fields such as [detail](https://www.rfc-editor.org/rfc/rfc9457.html#name-detail), [instance](https://www.rfc-editor.org/rfc/rfc9457.html#name-instance) and 
+        [type](https://www.rfc-editor.org/rfc/rfc9457.html#name-type) are encouraged to be leveraged to provide more contextual feedback about the error, 
+        while being conscious of not disclosing sensitive information for security concerns.
+      </p>
+      <p>
+        Implementers SHOULD catch all server errors in the best of their capabilities. 
+        Endpoints should avoid returning improperly handled 500 errors in a production environment leading to potential [information disclosure](https://owasp.org/www-community/Improper_Error_Handling).
+      </p>
+      <h4>Relationship between verification and error codes</h4>
+      <p>
+        While performing verification of a credential and/or presentation, an implementer might be in a situation where they must raise an error.
+        This is an ambigous case between http protocol related errors and VC specification related errors. 
+        Given a verifiableCredential:
+        For cases where the data model is wrong or the proof is invalid, a 400 invalid input should be returned.
+        For cases where the a verificaiton method cannot be resolved, a 404 missing ressource should be returned.
+        For cases where the validity is bad or the status is invalid, a 422 unprocessable entity should be returned, 
+        meaning the verifier has no intention to process the credential further.
+
+        The logic is to differentiate between a verifier's verification processes and validation processes.
+        
+        As thus, the following mapping of status and title should be applied:
+        - For data model errors, return 400: Data Model
+        - For malformed proof, return 400: Proof Malformed
+        - For invalid proof, return 422: Proof Invalid
+        - For invalid credential/presentation, return 422: Validity Period
+        - For failed status checks, return 422: Status Invalid
+      </p>
+      <h4>References</h4>
+      <ul>
+        <li>[OWASP cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Error_Handling_Cheat_Sheet.html) on error handling</li>
+
+      </ul>
+    </section>
+
   </section>
 
   <section class="appendix">

--- a/index.html
+++ b/index.html
@@ -464,6 +464,7 @@ timeliness of the VC; leaving the Verifier Coordinator to finish Applying any bu
             (Verifier) &bull; Storage Service (Holder)
           </strong>
         </p>
+      </section>
       <section>
         <h3>Workflow Service</h3>
         <p>
@@ -1176,48 +1177,40 @@ Connection: keep-alive
     <section>
       <h3>Error Handling</h3>
       <p>
-        Error handling and messaging in the VC-API follows [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html). 
-        Implementers SHOULD include a [status](https://www.rfc-editor.org/rfc/rfc9457.html#name-status) 
-        and a [title](https://www.rfc-editor.org/rfc/rfc9457.html#name-title) 
-        in the error response body relating to the specifics of the endpoint on which the error occurs. 
+        Error handling and messaging in the VC-API aligns with Problem Details for HTTP APIs [[RFC9457]]. 
+        Implementers SHOULD include a status and a title in the error response body 
+        relating to the specifics of the endpoint on which the error occurs. 
       <p>
       <p>
         Aligning on error handling and messaging will greatly improve test-suites accuracy 
         when identifying technical friction impacting interoperability.
       </p>
       </p>
-        Leveraging other fields such as [detail](https://www.rfc-editor.org/rfc/rfc9457.html#name-detail), 
-        [instance](https://www.rfc-editor.org/rfc/rfc9457.html#name-instance),
-        and [type](https://www.rfc-editor.org/rfc/rfc9457.html#name-type) 
-        is encouraged, to provide more contextual feedback about the error, 
-        while being conscious of security concerns and hence not disclosing
-        sensitive information.
+        Leveraging other fields such as detail, instance and type is encouraged, 
+        to provide more contextual feedback about the error, 
+        while being conscious of security concerns and hence not disclosing sensitive information.
       </p>
       <p>
         Implementers should handle all server errors to the best of their capabilities. 
         Endpoints should avoid returning improperly handled 500 errors in production 
-        environments, as these may lead to [information disclosure](https://owasp.org/www-community/Improper_Error_Handling).
+        environments, as these may lead to information disclosure.
       </p>
-      <h4>Relationship between verification and error handling</h4>
+      <h4>Relationship between verification, validation and error handling</h4>
       <p>
-        An implementer should avoid raising errors while performing
-        [verification](https://w3c.github.io/vc-data-model/#verification), 
-        and instead should gather 
-        [ProblemDetails](https://w3c.github.io/vc-data-model/#problem-details) 
-        objects to include in the verification results.
+        It is recommended to avoid raising errors while performing verification, 
+        and instead gather ProblemDetails objects to include in the verification results.
       </p>
       <h4>Types of ProblemDetails</h4>
-        At the time of writting, ProblemDetails types refer to the [vc data model specification](https://w3c.github.io/vc-data-model/#problem-details)
-        It would be good to include additional types as time goes on.
-        <h5>Example ProblemDetails</h4>
-          <code>
+        An implementer can refer to the [[VC-DATA-MODEL-2.0]] and the [[VC-BITSTRING-STATUS-LIST]] for currently defined ProblemDetails types.
+        <pre class="example"
+          title="ProblemDetails">
           {
             "type": "https://www.w3.org/TR/vc-data-model#CRYPTOGRAPHIC_SECURITY_ERROR",
             "status": 400,
             "title": "CRYPTOGRAPHIC_SECURITY_ERROR",
             "detail": "The cryptographic security mechanism couldn't be verified. This is likely due to a malformed proof or an invalid verificationMethod."
           }
-          </code>
+        </pre>
       <h4>Verification Response</h4>
         <h5>Errors and Warnings</h5>
         Errors are ProblemDetails relating to cryptography, data model and malformed context.
@@ -1226,8 +1219,8 @@ Connection: keep-alive
         The VerificationResponse object MUST have the verified value set to false if an error is included.
         The VerificationResponse object MUST have the verified value set to true if no errors are included.
 
-        <h5>Verification Response Example</h5>
-        <code>
+        <pre class="example"
+          title="Verification Response">
           {
             "verified": false,
             "document": verifiableCredential,
@@ -1237,7 +1230,7 @@ Connection: keep-alive
             "warnings": [ProblemDetails],
             "errors": [ProblemDetails]
           }
-        </code>
+        </pre>
     </section>
 
   </section>

--- a/issuer.yml
+++ b/issuer.yml
@@ -42,8 +42,6 @@ paths:
             The request could not be processed due to one of the following reasons:
                         - The provided value of 'issuer' does not match the expected configuration.
                         - Another condition that results in a Bad Request.
-        "500":
-          description: error!
   /credentials/status:
     post:
       summary: Updates the status of an issued credential
@@ -68,8 +66,6 @@ paths:
           description: Bad Request
         "404":
           description: Credential not found
-        "500":
-          description: Internal Server Error
 components:
   securitySchemes:
     $ref: "./components/SecuritySchemes.yml#/components/securitySchemes"

--- a/verifier.yml
+++ b/verifier.yml
@@ -39,8 +39,6 @@ paths:
                 $ref: "#/components/schemas/VerifyCredentialResponse"
         "400":
           description: invalid input!
-        "500":
-          description: error!
   /presentations/verify:
     post:
       summary: Verifies a Presentation with or without proofs attached and returns a verificationResult in the response body.
@@ -73,8 +71,6 @@ paths:
           description: Payload too large
         "429":
           description: Request rate limit exceeded.
-        "500":
-          description: Internal Server Error
   /challenges:
     post:
       summary: Passing an empty body to this endpoint creates and returns a challenge string in the response body.
@@ -93,8 +89,6 @@ paths:
                 $ref: "#/components/schemas/CreateChallengeResponse"
         "400":
           description: Invalid or malformed input
-        "500":
-          description: Internal server error
 components:
   securitySchemes:
     $ref: "./components/SecuritySchemes.yml#/components/securitySchemes"


### PR DESCRIPTION
Addresses #383 #340 #331 and #141 

Standing questions:

[RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html) or [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807)?

What should the relationship with [verification algorithms](https://w3c.github.io/vc-data-model/#algorithms) from the spec be?

Should we define specific error codes for each [ProblemDetails](https://w3c.github.io/vc-data-model/#problem-details)?

Is it fair to assume that if an errors are returned the credential is not verified but if only warning are returned it is verified? (see list of error/warnings in the PR for details)

Keyword [status](https://datatracker.ietf.org/doc/html/rfc7807#section-3.1) vs code...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OpSecId/vc-api/pull/389.html" title="Last updated on Jun 18, 2024, 7:20 PM UTC (bc3b5c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/389/c02e73f...OpSecId:bc3b5c5.html" title="Last updated on Jun 18, 2024, 7:20 PM UTC (bc3b5c5)">Diff</a>