### PR TITLE
Issuing EnvelopedVerifiableCredentials

### DIFF
--- a/components/EnvelopedVerifiableCredential.yml
+++ b/components/EnvelopedVerifiableCredential.yml
@@ -23,7 +23,7 @@ components:
             type: string
         "id":
           type: string
-          description: This MUST be a "data:" URL [RFC2397] that expresses a secured verifiable credential using an enveloping security scheme.
+          description: This MUST be a "data:" scheme URL [RFC2397] that expresses a secured verifiable credential using an enveloping security scheme.
         "type":
           type: string
           description: This MUST be EnvelopedVerifiableCredential.

--- a/components/EnvelopedVerifiableCredential.yml
+++ b/components/EnvelopedVerifiableCredential.yml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  version: "0.0.3-unstable"
+  title: VC API
+  description: This is an Experimental Open API Specification for the [VC Data Model](https://www.w3.org/TR/vc-data-model/).
+  license:
+    name: W3C Software and Document License
+    url: http://www.w3.org/Consortium/Legal/copyright-software.
+  contact:
+    name: GitHub Source Code
+    url: https://github.com/w3c-ccg/vc-api
+paths:
+components:
+  schemas:
+    EnvelopedVerifiableCredential:
+      type: object
+      description: An object used to associate an enveloped verifiable credential with the verifiableCredential property in a verifiable presentation.
+      properties:
+        "@context":
+          type: array
+          description: The JSON-LD context of the enveloped verifiable credential.
+          items:
+            type: string
+        "id":
+          type: string
+          description: This MUST be a "data:" URL [RFC2397] that expresses a secured verifiable credential using an enveloping security scheme.
+        "type":
+          type: string
+          description: This MUST be EnvelopedVerifiableCredential.
+      example:
+        {
+          "@context": "https://www.w3.org/ns/credentials/v2",
+          "id": "data:application/vc+sd-jwt;QzVjV...RMjU",
+          "type": "EnvelopedVerifiableCredential"
+        }

--- a/components/IssueCredentialSuccess.yml
+++ b/components/IssueCredentialSuccess.yml
@@ -19,9 +19,6 @@ components:
         verifiableCredential:
           type: object
           description: A JSON-LD Verifiable Credential with a proof.
-          allOf:
-            - $ref: "./Credential.yml#/components/schemas/Credential"
-            - type: object
-              properties:
-                proof:
-                  $ref: "./DataIntegrityProof.yml#/components/schemas/DataIntegrityProof"
+          oneOf:
+            - $ref: "./VerifiableCredential.yml#/components/schemas/VerifiableCredential"
+            - $ref: "./EnvelopedVerifiableCredential.yml#/components/schemas/EnvelopedVerifiableCredential"


### PR DESCRIPTION
This PR adds [EnvelopedVerifiableCredential](https://www.w3.org/TR/vc-data-model-2.0/#enveloped-verifiable-credentials) as an allowed schema in the `IssueCredentialSuccess` response object.

The impetus for this PR is #357 . 