### PR TITLE
docs(fix): move paragraphs that should be in the Storage Services section from the Workflow Service section

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,18 +464,6 @@ timeliness of the VC; leaving the Verifier Coordinator to finish Applying any bu
             (Verifier) &bull; Storage Service (Holder)
           </strong>
         </p>
-      </section>
-      <section>
-        <h3>Workflow Service</h3>
-        <p>
-The Workflow Service provides a way for coordinators to automate specific
-interactions for specific users. Each role (Holder, Issuer, and Verifier)
-can run their own Workflow Service to create and manage exchanges that
-realize particular workflows. Administrators configure the workflow system
-to support particular flows. Then, when the business rules justify it,
-coordinators create exchanges at their Workflow Service and give authorized
-access to those exchanges to any party. 
-        </p>
         <p>
 Each actor in the system is expected to store their own verifiable
 credentials, as needed. Several known implementations use secure data
@@ -496,6 +484,18 @@ bespoke Issuer and Storage Coordinators, any necessary integrations can simply
 be part of that bespoke customization. We expect different
 implementations to compete on the ease of integration into various
 back-end storage platforms.
+        </p>
+      </section>
+      <section>
+        <h3>Workflow Service</h3>
+        <p>
+The Workflow Service provides a way for coordinators to automate specific
+interactions for specific users. Each role (Holder, Issuer, and Verifier)
+can run their own Workflow Service to create and manage exchanges that
+realize particular workflows. Administrators configure the workflow system
+to support particular flows. Then, when the business rules justify it,
+coordinators create exchanges at their Workflow Service and give authorized
+access to those exchanges to any party. 
         </p>
       </section>
       <section>


### PR DESCRIPTION
Fixes: https://github.com/w3c-ccg/vc-api/issues/404


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/laysakura/vc-api/pull/408.html" title="Last updated on Jul 23, 2024, 7:54 PM UTC (0e35a25)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/408/066f030...laysakura:0e35a25.html" title="Last updated on Jul 23, 2024, 7:54 PM UTC (0e35a25)">Diff</a>