### PR TITLE
Add notes to Issue Credential and Create Presentation regarding different media types

### DIFF
--- a/index.html
+++ b/index.html
@@ -767,6 +767,12 @@ The following APIs are defined for issuing a Verifiable Credential:
         <p>
         </p>
 
+        <p class="note" title="Issued credential media types">
+          An `EnvelopedVerifiableCredential` can be returned in the `IssueCredentialSuccess` response
+          in order to issue credentials with a media type other than `application/vc`,
+          such as `application/vc+sd-jwt`.
+        </p>
+
         <div class="api-detail"
           data-api-endpoint="post /credentials/issue"></div>
       </section>
@@ -874,6 +880,12 @@ strongly advised to not assign semantics to any human-readable values.
       <section>
         <h4>Create Presentation</h4>
         <p>
+        </p>
+
+        <p class="note" title="Presentation media types">
+          An `EnvelopedVerifiablePresentation` can be returned in the response
+          in order to create presentations with a media type other than `application/vp`,
+          such as `application/vp+jwt`.
         </p>
 
         <div class="api-detail"


### PR DESCRIPTION
Following up on https://github.com/w3c-ccg/vc-api/issues/357#issuecomment-2327254214, this PR adds notes to indicate that `Enveloped` objects can be used to support different credential and presentation media types.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/417.html" title="Last updated on Sep 10, 2024, 6:39 PM UTC (233edeb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/417/f2ae3bd...233edeb.html" title="Last updated on Sep 10, 2024, 6:39 PM UTC (233edeb)">Diff</a>