### PR TITLE
Add proof to schema for credentials intended for issuance

### DIFF
--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -90,10 +90,13 @@ components:
           type: object
           description: The subject
         "proof":
+          type: object
           description: An optional proof for credentials that are secured using proof sets or chains.
           oneOf: 
             - type: object
             - type: array
+              items: 
+                type: object
       example:
         {
           "@context":

--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -58,8 +58,8 @@ components:
                 {
                   "type": "BachelorDegree",
                   "name": "Bachelor of Science and Arts",
-                },
-            },
+                }
+            }
         }
     UnsecuredCredential:
       type: object
@@ -89,6 +89,11 @@ components:
         "credentialSubject":
           type: object
           description: The subject
+        "proof":
+          description: An optional proof for credentials that are secured using proof sets or chains.
+          oneOf: 
+            - type: object
+            - type: array
       example:
         {
           "@context":
@@ -107,6 +112,6 @@ components:
                 {
                   "type": "BachelorDegree",
                   "name": "Bachelor of Science and Arts",
-                },
-            },
+                }
+            }
         }

--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -63,7 +63,7 @@ components:
         }
     UnsecuredCredential:
       type: object
-      description: A W3C Verifiable Credential without a proof.
+      description: A W3C Verifiable Credential intended for issuance.
       properties:
         "@context":
           type: array

--- a/respec-oas.js
+++ b/respec-oas.js
@@ -285,11 +285,16 @@ function renderJsonSchemaObject(schema) {
   } else if(schema.oneOf) {
     objectRendering += ' either ';
     let itemCount = 0;
-    for(item of schema.oneOf) {
+    for(const item of schema.oneOf) {
       if(item.type === 'string') {
         objectRendering += 'a string';
       } else if(item.type === 'object') {
         objectRendering += renderJsonSchemaObject(item);
+      } else if(item.type === 'array') {
+        objectRendering += 'an array';
+        if(item.items) {
+          objectRendering += ` of ${item.items.type}(s)`;
+        }
       }
 
       itemCount += 1;
@@ -307,7 +312,7 @@ function renderJsonSchemaObject(schema) {
       }
     } else {
       objectRendering += 'an object of the following form: <dl>';
-      for(property in schema.properties) {
+      for(const property in schema.properties) {
         const value = schema.properties[property];
         objectRendering += renderJsonSchemaProperty(property, value);
       }


### PR DESCRIPTION
- [x] Check to ensure minor changes to `res-oas.js` did not cause any regressions

Features:
- Adds support for `type: array` to `oneOf` schemas
- Adds `proof` to issue credential API endpoint schema
- Redefines UnsecuredCredential  in components to allow it to optionally have a proof

Addresses some, but not all of this issue: https://github.com/w3c-ccg/vc-api/issues/422
