### PR TITLE
Fix local exchangeId in exchange example.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1202,7 +1202,7 @@ sequenceDiagram
     autonumber
     Note right of H: Start exchange
     W->>I: Initiate
-    Note right of W: POST /workflows/123/exchanges/123 &mdash; HTTP request to start exchange (e.g., send credentials, get credentials)
+    Note right of W: POST /workflows/123/exchanges/abc &mdash; HTTP request to start exchange (e.g., send credentials, get credentials)
     I->>W: Verifiable Presentation Request (VPR)
     Note left of I: VPR includes method of interaction, for purposes of exchange
     W->>I: Verifiable Presentation (VP)


### PR DESCRIPTION
As this example is a single exchange, the exchange id should be the same in both participate calls.
See issue #425 for discussion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/427.html" title="Last updated on Oct 9, 2024, 1:31 PM UTC (c81c87b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/427/26ee3f6...c81c87b.html" title="Last updated on Oct 9, 2024, 1:31 PM UTC (c81c87b)">Diff</a>