### PR TITLE
Embed exchange creation response in `exchange` property.

### DIFF
--- a/exchanges.yml
+++ b/exchanges.yml
@@ -374,8 +374,8 @@ components:
               type: string
               description: The local exchange ID that identifies the exchange.
             sequence:
-              type: string
-              description: A sequence number for the exchange. Set to "0" on creation.
+              type: number
+              description: A sequence number for the exchange. Set to 0 on creation.
             ttl:
               type: string
               description: The time to live for the exchange.

--- a/exchanges.yml
+++ b/exchanges.yml
@@ -372,28 +372,24 @@ components:
       additionalProperties: false
       description: Object containing information about an active exchange.
       properties:
-        exchange:
+        id:
+          type: string
+          description: The local exchange ID that identifies the exchange.
+        sequence:
+          type: number
+          description: A sequence number for the exchange. Set to 0 on creation.
+        ttl:
+          type: string
+          description: The time to live for the exchange.
+        step:
+          type: string
+          description: The current step in the exchange.
+        state:
+          type: string
+          description: The status ("pending" | "active" | "complete" | "invalid") of the exchange, set to "pending" on creation.
+        variables:
           type: object
-          description: The active exchange.
-          properties:
-            id:
-              type: string
-              description: The local exchange ID that identifies the exchange.
-            sequence:
-              type: number
-              description: A sequence number for the exchange. Set to 0 on creation.
-            ttl:
-              type: string
-              description: The time to live for the exchange.
-            step:
-              type: string
-              description: The current step in the exchange.
-            state:
-              type: string
-              description: The status ("pending" | "active" | "complete" | "invalid") of the exchange, set to "pending" on creation.
-            variables:
-              type: object
-              description: Template variables to be used in the exchange.
+          description: Template variables to be used in the exchange.
     WorkflowStep:
       type: object
       description: Object containing information about a workflow step.

--- a/exchanges.yml
+++ b/exchanges.yml
@@ -31,12 +31,15 @@ paths:
             schema:
               $ref: "#/components/schemas/CreateWorkflowRequest"
       responses:
-        "200":
+        "204":
           description: Workflow successfully created!
-          content:
-            application/json:
+          headers:
+            Location:
               schema:
-                $ref: "#/components/schemas/CreateWorkflowResponse"
+                type: string
+                format: uri
+                description: The HTTP URL used to retrieve workflow metadata.
+                example: https://issuer.example.com/workflows/123
         "400":
           description: Invalid input
         "401":
@@ -90,12 +93,15 @@ paths:
             schema:
               $ref: "#/components/schemas/CreateExchangeRequest"
       responses:
-        "200":
+        "204":
           description: Exchange successfully created!
-          content:
-            application/json:
+          headers:
+            Location:
               schema:
-                $ref: "#/components/schemas/CreateExchangeResponse"
+                type: string
+                format: uri
+                description: The HTTP URL used to retrieve exchange metadata.
+                example: https://issuer.example.com/workflows/123/exchanges/abc
         "400":
           description: Invalid input
         "401":

--- a/exchanges.yml
+++ b/exchanges.yml
@@ -15,7 +15,7 @@ info:
 paths:
   /workflows:
     post:
-      summary: Creates a new workflow and returns its information in the response body.
+      summary: Creates a new workflow and returns location of workflow metadata in a response header.
       tags:
         - Credentials
       security:
@@ -23,7 +23,7 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: createWorkflow
-      description: Creates a new workflow and returns workflowId in the response body.
+      description: Creates a new workflow and returns location of workflow metadata in a response header.
       x-expectedCaller: Administrators
       requestBody:
         content:
@@ -75,7 +75,7 @@ paths:
           description: Internal Error
   /workflows/{localWorkflowId}/exchanges:
     post:
-      summary: Creates a new exchange and returns exchange metadata in the response body.
+      summary: Creates a new exchange and returns location of exchange metadata in a response header.
       tags:
         - Credentials
       security:
@@ -83,7 +83,7 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: createExchange
-      description: Creates a new exchange and returns exchange metadata in the response body.
+      description: Creates a new exchange and returns location of exchange metadata in a response header.
       x-expectedCaller: Owner Coordinator
       parameters:
         - $ref: "./components/parameters/path/LocalWorkflowId.yml"

--- a/exchanges.yml
+++ b/exchanges.yml
@@ -373,6 +373,9 @@ components:
             id:
               type: string
               description: The local exchange ID that identifies the exchange.
+            sequence:
+              type: string
+              description: A sequence number for the exchange. Set to "0" on creation.
             ttl:
               type: string
               description: The time to live for the exchange.

--- a/exchanges.yml
+++ b/exchanges.yml
@@ -221,45 +221,6 @@ components:
         id:
           type: string
           description: The ID that will be used for the created workflow. Passing an ID is OPTIONAL.
-    CreateWorkflowResponse:
-      type: object
-      additionalProperties: false
-      description: Response containing the created workflow config Object.
-      properties:
-        id:
-          type: string
-          description: The URL that uniquely identifies the created workflow.
-        steps:
-          type: object
-          description: One or more steps required to complete an exchange on the workflow.
-          properties:
-            stepName:
-              type: object
-              description: The name of the step.
-              properties:
-                step:
-                  $ref: "#/components/schemas/WorkflowStep"
-        initialStep:
-          type: string
-          description: The step from the above set that the exchange starts on.
-        controller:
-          type: string
-          description: The controller of the instance. Returning controller is OPTIONAL.
-        authorization:
-          type: object
-          description: Authorization scheme information (e.g., OAuth2 configuration). Returning authorization is OPTIONAL.
-        credentialTemplates:
-          type: array
-          description: One or more VC templates for issuance. Returning credentialTemplates is OPTIONAL.
-          items:
-            type: object
-            properties:
-              type:
-                type: string
-                description: The type of template.
-              template:
-                type: string
-                description: The template itself.
     GetWorkflowResponse:
       type: object
       additionalProperties: false
@@ -318,38 +279,6 @@ components:
                   template:
                     type: string
                     description: The template itself.
-    CreateExchangeResponse:
-      type: object
-      additionalProperties: false
-      description: Object containing information about a created exchange.
-      properties:
-        id:
-          type: string
-          description: The URL that uniquely identifies the exchange.
-        sequence:
-          type: number
-          description: A sequence number for the exchange. Set to 0 on creation.
-        ttl:
-          type: string
-          description: The time to live for the created exchange.
-        variables:
-          type: array
-          description: Template variables to be used in the exchange.
-          items:
-            type: object
-            properties:
-              type:
-                type: string
-                description: The type of template.
-              template:
-                type: string
-                description: The template itself.
-        state:
-          type: string
-          description: The status ("pending" | "active" | "complete" | "invalid") of the exchange, set to "pending" on creation.
-        step:
-          type: string
-          description: The semantic string ID for the current step.
     ExchangeParticipationResponse:
       type: object
       description: Either what the exchange is expecting next or a result of the exchange.

--- a/exchanges.yml
+++ b/exchanges.yml
@@ -72,7 +72,7 @@ paths:
           description: Internal Error
   /workflows/{localWorkflowId}/exchanges:
     post:
-      summary: Creates a new exchange and returns exchangeId and time to live in the response body.
+      summary: Creates a new exchange and returns exchange metadata in the response body.
       tags:
         - Credentials
       security:
@@ -80,7 +80,7 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: createExchange
-      description: Creates a new exchange and returns exchangeId and time to live in the response body.
+      description: Creates a new exchange and returns exchange metadata in the response body.
       x-expectedCaller: Owner Coordinator
       parameters:
         - $ref: "./components/parameters/path/LocalWorkflowId.yml"
@@ -317,7 +317,7 @@ components:
       additionalProperties: false
       description: Object containing information about a created exchange.
       properties:
-        exchangeId:
+        id:
           type: string
           description: The URL that uniquely identifies the exchange.
         sequence:


### PR DESCRIPTION
This PR addresses Issue #453 by embedding the exchange creation response in the `exchange` property and renaming `exchangeId` to `id`.

@dlongley As it was [your recommendation](https://github.com/w3c-ccg/vc-api/issues/453#issuecomment-2663880455) to return the exchange in `exchange` during exchange creation (which is apparently consistent with the exchange retrieval response format), should I create an issue to do the same for workflow creation? If so, it seems the general pattern will be to include the body parameters directly in the request, and return it in an intermediate property in the response (e.g., `exchange`, `workflow`). Before we move forward, it would be good to confirm this pattern generally.