### PR TITLE
Convert `createChallenge` property from `string` to `boolean`.

### DIFF
--- a/exchanges.yml
+++ b/exchanges.yml
@@ -411,7 +411,7 @@ components:
       description: Step data to be included if a template is not used.
       properties:
         createChallenge:
-          type: string
+          type: boolean
           description: An optional step directive that tells the exchange to handle challenge management via a VC API verifier service it has a zcap for.
         verifiablePresentationRequest:
           $ref: "./components/VerifiablePresentationRequest.yml#/components/schemas/VerifiablePresentationRequest"


### PR DESCRIPTION
This PR addresses Issue #455 by converting the format of the `createChallenge` workflow step property from `string` to `boolean`.