### PR TITLE
Convert sequence format from `string` to `number`.

### DIFF
--- a/exchanges.yml
+++ b/exchanges.yml
@@ -321,8 +321,8 @@ components:
           type: string
           description: The URL that uniquely identifies the exchange.
         sequence:
-          type: string
-          description: A sequence number for the exchange. Set to "0" on creation.
+          type: number
+          description: A sequence number for the exchange. Set to 0 on creation.
         ttl:
           type: string
           description: The time to live for the created exchange.


### PR DESCRIPTION
This PR address Issue #447 by converting `sequence` format from `string` to `number`.