### PR TITLE
Remove GET /credentials endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -867,7 +867,7 @@ The following APIs are defined for issuing a Verifiable Credential:
       </p>
 
       <table class="simple api-summary-table"
-        data-api-path="/credentials /credentials/{id}
+        data-api-path="/credentials/{id}
           /credentials/issue /credentials/status"></table>
 
       <section>
@@ -883,15 +883,6 @@ The following APIs are defined for issuing a Verifiable Credential:
 
         <div class="api-detail"
           data-api-endpoint="post /credentials/issue"></div>
-      </section>
-
-      <section>
-        <h4>Get Credentials</h4>
-        <p>
-        </p>
-
-        <div class="api-detail"
-          data-api-endpoint="get /credentials"></div>
       </section>
 
       <section>


### PR DESCRIPTION
Issuing Section -
Remove the Get /credentials endpoint from the specification

Related Issue https://github.com/w3c-ccg/vc-api/issues/302

**Note:** Close duplicate PR https://github.com/w3c-ccg/vc-api/pull/476 

Reviewers: @msporny 