### PR TITLE
Clarify when proofs can be appended to by issuance endpoint.

### DIFF
--- a/index.html
+++ b/index.html
@@ -897,9 +897,9 @@ type other than `application/vc`, such as `application/vc+sd-jwt`.
           data-api-endpoint="post /credentials/issue"></div>
 
         <p>
-If a use case requires an issuing instance to attach multiple proofs to the
-provided `credential`, it MUST attach all of these proofs with a single call 
-to the `/credentials/issue` endpoint.
+If a use case requires an issuer instance to attach multiple proofs to the
+provided `credential`, the instance MUST attach all of these proofs during 
+a single call to the `/credentials/issue` endpoint.
         </p>
         <p>
 If a provided `credential` already contains one or more proofs,

--- a/index.html
+++ b/index.html
@@ -884,8 +884,7 @@ The following APIs are defined for issuing a Verifiable Credential:
       <section>
         <h4>Issue Credential</h4>
         <p>
-This endpoint is used to attach one or more proofs to a
-[=verifiable credential=].
+This endpoint is used to issue a [=verifiable credential=].
         </p>
 
         <p class="note" title="Issued credential media types">
@@ -899,8 +898,8 @@ type other than `application/vc`, such as `application/vc+sd-jwt`.
 
         <p>
 If a use case requires an issuing instance to attach multiple proofs to the
-provided `credential`, an issuing instance SHOULD attach all proofs during a
-single call to the `/credentials/issue` endpoint.
+provided `credential`, it MUST attach all of these proofs with a single call 
+to the `/credentials/issue` endpoint.
         </p>
         <p>
 If a provided `credential` already contains one or more proofs,

--- a/index.html
+++ b/index.html
@@ -884,16 +884,31 @@ The following APIs are defined for issuing a Verifiable Credential:
       <section>
         <h4>Issue Credential</h4>
         <p>
+This endpoint is used to attach one or more proofs to a
+[=verifiable credential=].
         </p>
 
         <p class="note" title="Issued credential media types">
-          An `EnvelopedVerifiableCredential` can be returned in the `IssueCredentialSuccess` response
-          in order to issue credentials with a media type other than `application/vc`,
-          such as `application/vc+sd-jwt`.
+An `EnvelopedVerifiableCredential` can be returned in the
+`IssueCredentialSuccess` response in order to issue credentials with a media
+type other than `application/vc`, such as `application/vc+sd-jwt`.
         </p>
 
         <div class="api-detail"
           data-api-endpoint="post /credentials/issue"></div>
+
+        <p>
+If a use case requires an issuing instance to attach multiple proofs to the
+provided `credential`, an issuing instance SHOULD attach all proofs during a
+single call to the `/credentials/issue` endpoint.
+        </p>
+        <p>
+If a provided `credential` already contains one or more proofs,
+an issuing instance SHOULD append its proofs to the list of existing proofs
+provided by the caller, converting a single proof value to an array of
+proof values if necessary. An issuing instance MAY be configured to return an
+error if `credential` values that contain existing `proof` values are provided.
+        </p>
       </section>
 
       <section>


### PR DESCRIPTION
This PR is an attempt to address issue #337 by stating when `proof` can be attached to a provided `credential`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/478.html" title="Last updated on May 20, 2025, 7:50 PM UTC (65b2e01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/478/1f3de7e...65b2e01.html" title="Last updated on May 20, 2025, 7:50 PM UTC (65b2e01)">Diff</a>