### PR TITLE
Ensure that GET /credentials/{{id}} includes object that contains `verifiableCredential`.

### DIFF
--- a/components/VerifiableCredentialResponse.yml
+++ b/components/VerifiableCredentialResponse.yml
@@ -12,9 +12,9 @@ info:
 paths:
 components:
   schemas:
-    IssueCredentialSuccess:
+    VerifiableCredentialResponse:
       type: object
-      description: The format returned from a successful issue request.
+      description: The format returned from a successful request for a verifiable credential.
       properties:
         verifiableCredential:
           type: object

--- a/holder.yml
+++ b/holder.yml
@@ -33,8 +33,7 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: "./components/Credential.yml#/components/schemas/Credential"
-                  - $ref: "./components/VerifiableCredential.yml#/components/schemas/VerifiableCredential"
+                  - $ref: "./components/VerifiableCredentialResponse.yml#/components/schemas/VerifiableCredentialResponse"
         "400":
           description: Bad Request
         "401":

--- a/index.html
+++ b/index.html
@@ -886,11 +886,11 @@ This endpoint is used to issue a [=verifiable credential=].
         </p>
 
         <p class="note" title="Issued credential media types">
-An `EnvelopedVerifiableCredential` can be returned in the response in order to
-issue credentials with a media type other than `application/vc`, such as
+To issue credentials with a media type other than `application/vc` — such as
 `application/mdoc`, `application/vc+sd-jwt`,
 `application/vcb;barcode-format=qr_code`, or
-`application/vcb;barcode-format=pdf417`.
+`application/vcb;barcode-format=pdf417` — an `EnvelopedVerifiableCredential`
+can be returned in the response.
         </p>
 
         <div class="api-detail"
@@ -898,7 +898,7 @@ issue credentials with a media type other than `application/vc`, such as
 
         <p>
 If a use case requires an issuer instance to attach multiple proofs to the
-provided `credential`, the instance MUST attach all of these proofs during
+provided `credential`, the instance MUST attach all of these proofs with
 a single call to the `/credentials/issue` endpoint.
         </p>
         <p>
@@ -946,11 +946,11 @@ This endpoint is used to verify a [=verifiable credential=].
         </p>
 
         <p class="note" title="Verify credential media types">
-An `EnvelopedVerifiableCredential` can be provided in the request in order to
-verify credentials with a media type other than `application/vc`, such as
+To verify credentials with a media type other than `application/vc`, such as
 `application/mdoc`, `application/vc+sd-jwt`,
 `application/vcb;barcode-format=qr_code`, or
-`application/vcb;barcode-format=pdf417`.
+`application/vcb;barcode-format=pdf417` — an `EnvelopedVerifiableCredential`
+can be provided in the request.
         </p>
 
         <div class="api-detail"

--- a/index.html
+++ b/index.html
@@ -886,9 +886,9 @@ This endpoint is used to issue a [=verifiable credential=].
         </p>
 
         <p class="note" title="Issued credential media types">
-An `EnvelopedVerifiableCredential` can be returned in the
-`IssueCredentialSuccess` response in order to issue credentials with a media
-type other than `application/vc`, such as `application/vc+sd-jwt`.
+An `EnvelopedVerifiableCredential` can be returned in the response in order to
+issue credentials with a media type other than `application/vc`, such as
+`application/mdoc` or `application/vc+sd-jwt`.
         </p>
 
         <div class="api-detail"
@@ -896,7 +896,7 @@ type other than `application/vc`, such as `application/vc+sd-jwt`.
 
         <p>
 If a use case requires an issuer instance to attach multiple proofs to the
-provided `credential`, the instance MUST attach all of these proofs during 
+provided `credential`, the instance MUST attach all of these proofs during
 a single call to the `/credentials/issue` endpoint.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -898,7 +898,7 @@ can be returned in the response.
 
         <p>
 If a use case requires an issuer instance to attach multiple proofs to the
-provided `credential`, the instance MUST attach all of these proofs with
+provided `credential`, the instance MUST attach all of these proofs in response to
 a single call to the `/credentials/issue` endpoint.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -888,7 +888,9 @@ This endpoint is used to issue a [=verifiable credential=].
         <p class="note" title="Issued credential media types">
 An `EnvelopedVerifiableCredential` can be returned in the response in order to
 issue credentials with a media type other than `application/vc`, such as
-`application/mdoc` or `application/vc+sd-jwt`.
+`application/mdoc`, `application/vc+sd-jwt`,
+`application/vcb;barcode-format=qr_code`, or
+`application/vcb;barcode-format=pdf417`.
         </p>
 
         <div class="api-detail"
@@ -940,6 +942,15 @@ The following APIs are defined for verifying a Verifiable Credential:
       <section>
         <h4>Verify Credential</h4>
         <p>
+This endpoint is used to verify a [=verifiable credential=].
+        </p>
+
+        <p class="note" title="Verify credential media types">
+An `EnvelopedVerifiableCredential` can be provided in the request in order to
+verify credentials with a media type other than `application/vc`, such as
+`application/mdoc`, `application/vc+sd-jwt`,
+`application/vcb;barcode-format=qr_code`, or
+`application/vcb;barcode-format=pdf417`.
         </p>
 
         <div class="api-detail"

--- a/issuer.yml
+++ b/issuer.yml
@@ -87,9 +87,9 @@ components:
           required: ['type', 'statusPurpose']
           additionalProperties: false
           properties:
-            id: 
+            id:
               type: string
-            type: 
+            type:
               type: string
             statusPurpose:
               type: string
@@ -119,5 +119,5 @@ components:
     IssueCredentialResponse:
       type: object
       properties:
-        IssueCredentialSuccess:
-          $ref: "./components/IssueCredentialSuccess.yml#/components/schemas/IssueCredentialSuccess"
+        IssueCredentialResponse:
+          $ref: "./components/VerifiableCredentialResponse.yml#/components/schemas/VerifiableCredentialResponse"


### PR DESCRIPTION
This PR is an attempt to address issue #398 by returning an object containing a `verifiableCredential`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/481.html" title="Last updated on Jun 3, 2025, 7:22 PM UTC (2c12a38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/481/23ab19c...2c12a38.html" title="Last updated on Jun 3, 2025, 7:22 PM UTC (2c12a38)">Diff</a>