### PR TITLE
Remove intermediate step property from workflow steps

### DIFF
--- a/exchanges.yml
+++ b/exchanges.yml
@@ -191,14 +191,10 @@ components:
       properties:
         steps:
           type: object
-          description: One or more steps required to complete an exchange on the workflow. Passing the steps object is REQUIRED.
+          description: One or more steps required to complete an exchange on the workflow. Passing the steps object is REQUIRED. The keys are step names and values are step configurations.
           properties:
-            stepName:
-              type: object
-              description: The name of the step.
-              properties:
-                step:
-                  $ref: "#/components/schemas/WorkflowStep"
+            theNameOfTheStep:
+              $ref: "#/components/schemas/WorkflowStep"
         initialStep:
           type: string
           description: The step from the above set that the exchange starts on. Passing intialStep is REQUIRED.
@@ -228,14 +224,10 @@ components:
       properties:
         steps:
           type: object
-          description: One or more steps required to complete an exchange on the workflow.
+          description: One or more steps required to complete an exchange on the workflow. The keys are step names and values are step configurations.
           properties:
-            stepName:
-              type: object
-              description: The name of the step.
-              properties:
-                step:
-                  $ref: "#/components/schemas/WorkflowStep"
+            theNameOfTheStep:
+              $ref: "#/components/schemas/WorkflowStep"
         initialStep:
           type: string
           description: The step from the above set that the exchange starts on.


### PR DESCRIPTION
This PR addresses issue #413 - Remove intermediate step property from workflow steps

## 📋 Changes Made

- [x] Removed confusing intermediate `step` property from workflow schema (#413)
- [x] Simplified workflow steps structure to use direct step name keys
- [x] Updated `CreateWorkflowRequest` and `GetWorkflowResponse` schemas in `exchange.yml` file
- [x] Improved schema clarity by using `theNameOfTheStep` placeholder

@msporny @dlongley ready for review.

Additionally, I have encountered a rendering issue in the generated documentation. In the `createWorkflow` endpoint, all attributes after `initialStep` are displayed a bit weirdly in the HTML output. I have been unable to identify the root cause of this rendering problem.

**Could you please:**
1. Verify that my understanding and implementation of issue #413 is correct
2. Help identify what might be causing the documentation rendering issues with the attributes following `initialStep`

I want to ensure that both the schema fix and the documentation display are working as expected before this is merged.