### PR TITLE
Update Proof description & Add proofId, previousProof properties

### DIFF
--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -91,8 +91,11 @@ components:
           description: The subject
         "proof":
           type: object
-          description: An optional proof for credentials that are secured using proof sets or chains.
-          oneOf: 
+          description: >
+            An optional proof or array of proofs for credentials that are secured using proof sets or chains. 
+            When present, the issuer instance configuration determines how these existing proofs are processed 
+            (appended to create proof sets/chains, or trigger an error).
+          oneOf:
             - type: object
             - type: array
               items: 

--- a/components/IssueCredentialOptions.yml
+++ b/components/IssueCredentialOptions.yml
@@ -38,6 +38,17 @@ components:
             auto-generate a credentialId if one is not supplied by the issuer
             coordinator, because doing so could create a partitioning error if the
             result is never received by the client.
+        proofId:
+          type: string
+          description: >
+            An optional identifier for the proof being added by this issuer instance. 
+            If not provided, the issuer service MAY auto-generate a proof identifier 
+            based on its configuration.
+        previousProof:
+          type: object
+          description: >
+            Optional reference to previous proof(s) when creating proof chains. 
+            The issuer instance configuration determines how this is processed.
       example:
         {
           "credentialId": "example.com/ad5d541f-db7a-4bff-97e1-d403ce403767",


### PR DESCRIPTION
This PR also addresses **#422** by clarifying how the `/credentials/issue` endpoint handles credentials with existing proofs as agreed upon in the 2025-05-27 call.

**Important Note:** Created a new PR for additional changes. This PR is related to PR https://github.com/w3c-ccg/vc-api/pull/495#issuecomment-3104499743

## 📋 Files & Changes Made

1. Update `components/Credential.yml` file - enhance `UnsecuredCredential` proof property description to `An optional proof or array of proofs for credentials that are secured using proof sets or chains. When present, the issuer instance configuration determines how these existing proofs are processed (appended to create proof sets/chains, or trigger an error).`
2. Update `components/IssueCredentialOptions.yml` - add optional `proofId` and `previousProof` properties  

**Section 3.8.1 Before Updates:**

<img width="850" height="555" alt="Screenshot 2025-07-22 at 3 17 18 PM" src="https://github.com/user-attachments/assets/bcc65cbf-6951-48a9-a6b6-43ea92c805d0" />


**Section 3.8.1 After Updates**

<img width="1347" height="802" alt="Screenshot 2025-07-22 at 3 11 00 PM" src="https://github.com/user-attachments/assets/8d3c11e0-18ec-4200-831f-56731aeafa21" />



________

@dlongley cc: @msporny @BigBlueHat @TallTed @PatStLouis  -- Ready for review.
