### PR TITLE
Add proof chain and set documentation to credential issuance

### DIFF
--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -91,7 +91,10 @@ components:
           description: The subject
         "proof":
           type: object
-          description: An optional proof for credentials that are secured using proof sets or chains.
+          description: >
+            An optional proof or array of proofs for credentials that are secured using proof sets or chains. 
+            When present, the issuer instance configuration determines how these existing proofs are processed 
+            (appended to create proof sets/chains, or trigger an error).
           oneOf: 
             - type: object
             - type: array

--- a/index.html
+++ b/index.html
@@ -909,15 +909,15 @@ instance SHOULD be configured to handle existing proofs in one of the following 
       </p>
       <ul>
         <li>
-          <strong>Proof Sets</strong>: Append their proofs to the list of existing proofs 
-          provided by the caller, converting a single proof value to an array of 
-          proof values if necessary, creating a proof set where multiple proofs exist 
-          in parallel.
+          <strong>Proof Sets</strong>: Append new proofs to the list of existing proofs 
+          provided by the caller, first converting any existing single proof to a list 
+          if necessary. Here there is no binding to any existing proofs; the new proofs 
+          exist in parallel with those previously provided by the caller.
         </li>
         <li>
-          <strong>Proof Chains</strong>: Append their proofs to create a proof chain 
-          where proofs are linked in a specific sequence, potentially using properties 
-          like <code>previousProof</code> to establish the chain relationship.
+          <strong>Proof Chains</strong>: Append new proofs to create or extend an existing 
+          proof chain. Here proofs are linked in a specific sequence, potentially using the 
+          <code>previousProof</code> property to establish the chain relationship.
         </li>
         <li>
           <strong>Error Handling</strong>: Return an error if <code>credential</code> 

--- a/index.html
+++ b/index.html
@@ -902,13 +902,33 @@ If a use case requires an issuer instance to attach multiple proofs to the
 provided `credential`, the instance MUST attach all of these proofs in response to
 a single call to the `/credentials/issue` endpoint.
         </p>
-        <p>
+       <p>
 If a provided `credential` already contains one or more proofs,
-an issuing instance SHOULD append its proofs to the list of existing proofs
-provided by the caller, converting a single proof value to an array of
-proof values if necessary. An issuing instance MAY be configured to return an
-error if `credential` values that contain existing `proof` values are provided.
-        </p>
+the behavior is determined by the issuer instance configuration. An issuing instance 
+SHOULD be configured to handle existing proofs in one of the following ways:
+      </p>
+      <ul>
+        <li>
+          <strong>Proof Sets</strong>: Append its proofs to the list of existing proofs 
+          provided by the caller, converting a single proof value to an array of 
+          proof values if necessary, creating a proof set where multiple proofs exist 
+          in parallel.
+        </li>
+        <li>
+          <strong>Proof Chains</strong>: Append its proofs to create a proof chain 
+          where proofs are linked in a specific sequence, potentially using properties 
+          like <code>previousProof</code> to establish the chain relationship.
+        </li>
+        <li>
+          <strong>Error Handling</strong>: Return an error if <code>credential</code> 
+          values that contain existing <code>proof</code> values are provided, when 
+          the instance is configured to only accept credentials without existing proofs.
+        </li>
+      </ul>
+      <p>
+The specific approach used depends on the issuer instance configuration and 
+the intended use case for the verifiable credential.
+      </p>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -904,18 +904,18 @@ a single call to the `/credentials/issue` endpoint.
         </p>
        <p>
 If a provided `credential` already contains one or more proofs,
-the behavior is determined by the issuer instance configuration. An issuing instance 
-SHOULD be configured to handle existing proofs in one of the following ways:
+the behavior is determined by the configuration of the issuer instance. An issuing 
+instance SHOULD be configured to handle existing proofs in one of the following ways:
       </p>
       <ul>
         <li>
-          <strong>Proof Sets</strong>: Append its proofs to the list of existing proofs 
+          <strong>Proof Sets</strong>: Append their proofs to the list of existing proofs 
           provided by the caller, converting a single proof value to an array of 
           proof values if necessary, creating a proof set where multiple proofs exist 
           in parallel.
         </li>
         <li>
-          <strong>Proof Chains</strong>: Append its proofs to create a proof chain 
+          <strong>Proof Chains</strong>: Append their proofs to create a proof chain 
           where proofs are linked in a specific sequence, potentially using properties 
           like <code>previousProof</code> to establish the chain relationship.
         </li>
@@ -926,7 +926,7 @@ SHOULD be configured to handle existing proofs in one of the following ways:
         </li>
       </ul>
       <p>
-The specific approach used depends on the issuer instance configuration and 
+The specific approach used depends on the configuration of the issuer instance and 
 the intended use case for the verifiable credential.
       </p>
       </section>


### PR DESCRIPTION
This PR addresses **https://github.com/w3c-ccg/vc-api/issues/422** by clarifying how the `/credentials/issue` endpoint handles credentials with existing proofs as agreed upon in the 2025-05-27 call.

**Background**
This PR replaces PR #495, which had corrupted commit history due to a rebase issue that lost proper attribution. I apologize for my mistake - this clean branch preserves everyone's contributions with correct authorship.

**Individual Contributions**
- @bparth24: [Add proof chain and set documentation to credential issuance](https://github.com/bparth24/vc-api/commit/5e13014dda494355176d8242d208001290e9779a)
- @TallTed: [contribution - Fix grammatical issues in issue credential section](https://github.com/bparth24/vc-api/commit/5f11d00c23270cccd8ebaf04bd1ce93e9102a3b2)
- @dlongley: [contribution to improve clarity and readability of existing proof scenarios](https://github.com/bparth24/vc-api/commit/c817e557eb0233e52804794e82d2011cbe94612a)

## 📋 Changes Made

- **Enhanced Issue Credential section** to document three configuration-based behaviors:
  - **Proof Sets**: Append proofs in parallel for cryptographic flexibility
  - **Proof Chains**: Link proofs sequentially for approval workflows  
  - **Error Handling**: Reject credentials with existing proofs when configured

- **Clarified instance configuration** determines proof processing behavior

**Note**
This replaces PR #495 due to commit history corruption. All improvements are preserved here with proper attribution.

If merged it will close: #422 and replaces: PR #495. In any case PR #495 should be closed right away.

@dlongley @msporny @TallTed - ready for review & merge.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bparth24/vc-api/pull/503.html" title="Last updated on Jul 30, 2025, 8:56 PM UTC (2026200)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/503/66ce09c...bparth24:2026200.html" title="Last updated on Jul 30, 2025, 8:56 PM UTC (2026200)">Diff</a>