### PR TITLE
Fix duplicate /presentations endpoint in Presenting section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1028,8 +1028,8 @@ The following APIs are defined for presenting a Verifiable Credential:
       <table class="simple api-summary-table"
         data-api-path="
           /credentials/derive /presentations
-          /presentations /presentations/{id}
-          /exchanges/ /exchanges/{exchange-id} /exchanges/{exchange-id}/{transaction-id}"
+          /presentations/{id}
+          /exchanges /exchanges/{exchange-id} /exchanges/{exchange-id}/{transaction-id}"
         ></table>
 
         <p class="advisement">


### PR DESCRIPTION
- Removes duplicate /presentations entry from data-api-path attribute
- Removes extra trailing slash from /exchanges/ to fix GET /exchanges endpoint
- Ensures each endpoint appears only once in the API summary table

---
After the above fix

<img width="866" height="621" alt="Screenshot 2025-07-30 at 2 52 33 PM" src="https://github.com/user-attachments/assets/11064934-2698-4b6d-8937-5826ee29bc8b" />

Addresses #504.

@dlongley @msporny 