### PR TITLE
Improve interaction protocols delegation documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1661,7 +1661,7 @@ result in the following response:
 {
   "protocols": {
     "website": "https://app.example/redirects/z8j3kfk2lQ",
-    "vcapi": "https://app.example/workflows/123/exchanges/987",
+    "vcapi": "https://saas.example/workflows/123/exchanges/987",
     "oid4vp": "openid4vp://?client_id=https%3A%2F%2Fapp.example%2Fworkflows%2F123%2Fexchanges%2F987%2Fopenid%2Fclient%2Fauthorization%2Fresponse&request_uri=https%3A%2F%2Fapp.example%2Fworkflows%2F123%2Fexchanges%2F987%2Fopenid%2Fclient%2Fauthorization%2Frequest'"
   }
 }

--- a/index.html
+++ b/index.html
@@ -1668,6 +1668,14 @@ result in the following response:
         </pre>
 
         <p>
+The protocols response enables delegation of protocol execution to third-party service 
+providers through the HTTPS domain trust model, similar to the delegation mechanism 
+described in the <a href="#get-exchange-protocols">Get Exchange Protocols</a> section. 
+For example, the website `app.example` can delegate the operation of the exchange to a partner 
+`saas.example` by using the `saas.example` domain in the list of protocols.
+        </p>
+
+        <p>
 When the [=interaction URL=] is fetched using any unrecognized `Accept` header,
 a `text/html` document MUST be returned with directions instructing a human
 being to use specific software that understands how to process interaction URLs.


### PR DESCRIPTION
This PR addresses the core requirements from issue #501 by:

- Updates the vcapi protocol URL example to use `saas.example` for delegation
- Adds cross-reference linking interaction protocols to exchange protocols delegation
- Provides a concrete example showing `app.example` delegating to `saas.example`


After Updates
--

<img width="833" height="754" alt="VC API Issue 501" src="https://github.com/user-attachments/assets/bdd73509-96b0-4c47-8bd2-362a33a164ae" />

----

These changes improve consistency between the interaction protocols and exchange protocols sections, and help readers understand the relationship between these two delegation approaches.

The issue also mentions that delegation via interaction URLs is more common in practice and references existing deployments that proxy interaction URLs to exchange protocol endpoints. 

I'm seeking feedback on whether additional documentation changes are needed to address these aspects of the issue.

Addresses #501.


@dlongley @msporny @TallTed - Ready for review
