### PR TITLE
Clarify VP verification scope and add implementer flexibility.

### DIFF
--- a/components/VerifyPresentationOptions.yml
+++ b/components/VerifyPresentationOptions.yml
@@ -14,8 +14,14 @@ components:
   schemas:
     VerifyPresentationOptions:
       type: object
-      additionalProperties: false
+      additionalProperties: true
       description: Options for specifying how a presentation is verified.
+
+        Implementations MAY extend this object with additional properties to control
+        verification behavior, such as enabling/disabling verification of contained
+        credentials for debugging purposes, or controlling specific aspects of
+        credential verification (status checks, validity periods, proof verification, etc.).
+      
       properties:
         challenge:
           type: string

--- a/components/VerifyPresentationOptions.yml
+++ b/components/VerifyPresentationOptions.yml
@@ -18,9 +18,15 @@ components:
       description: Options for specifying how a presentation is verified.
 
         Implementations MAY extend this object with additional properties to control
-        verification behavior, such as enabling/disabling verification of contained
-        credentials for debugging purposes, or controlling specific aspects of
-        credential verification (status checks, validity periods, proof verification, etc.).
+        verification behavior. Common extensions may include options to disable 
+        verification of contained credentials (e.g., for debugging or when only 
+        presentation-level verification is needed), fine-grained controls for 
+        credential verification aspects such as status checks, validity period 
+        validation, proof verification, and schema validation, and selective 
+        verification controls for specific credentials within the presentation.
+        
+        The API is compositional when credential verification is disabled or limited, 
+        indvidual credentials can be verified separately using the /credentials/verify endpoint.
       
       properties:
         challenge:

--- a/components/VerifyPresentationOptions.yml
+++ b/components/VerifyPresentationOptions.yml
@@ -20,12 +20,12 @@ components:
         Implementations MAY extend this object with additional properties to control
         verification behavior. Common extensions may include options to disable 
         verification of contained credentials (e.g., for debugging or when only 
-        presentation-level verification is needed), fine-grained controls for 
-        credential verification aspects such as status checks, validity period 
-        validation, proof verification, and schema validation, and selective 
+        presentation-level verification is needed); fine-grained controls for 
+        verification of credential aspects such as status checks, validity period 
+        validation, proof verification, and schema validation; and selective 
         verification controls for specific credentials within the presentation.
         
-        The API is compositional when credential verification is disabled or limited, 
+        The API is compositional when credential verification is disabled or limited;
         indvidual credentials can be verified separately using the /credentials/verify endpoint.
       
       properties:

--- a/index.html
+++ b/index.html
@@ -1009,7 +1009,7 @@ The verification process includes:
           <li>Verifying the presentation's own proof (including domain 
 and challenge validation)</li>
           <li>Verifying each contained verifiable credential's proof, 
-status, and validity periods</li>
+status, and validity period(s)</li>
           <li>Checking that the holder in the presentation matches 
 the verification method used in the presentation's proof</li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -998,6 +998,27 @@ can be provided in the request.
       <section>
         <h4>Verify Presentation</h4>
         <p>
+This endpoint is used to verify a <a>verifiable presentation</a> and, by default,
+all <a>verifiable credentials</a> contained within it.
+        </p>
+
+        <p>
+The verification process includes:
+        </p>
+        <ul>
+          <li>Verifying the presentation's own proof (including domain 
+and challenge validation)</li>
+          <li>Verifying each contained verifiable credential's proof, 
+status, and validity periods</li>
+          <li>Checking that the holder in the presentation matches 
+the verification method used in the presentation's proof</li>
+        </ul>
+
+        <p>
+Business rule validation (such as verifying that credential subjects 
+match the presentation holder, or authorization policies about who can 
+present which credentials) is outside the scope of this verification 
+endpoint and should be performed by the calling application.
         </p>
 
         <div class="api-detail"

--- a/verifier.yml
+++ b/verifier.yml
@@ -44,7 +44,7 @@ paths:
           description: invalid input!
   /presentations/verify:
     post:
-      summary: Verifies a Presentation with or without proofs attached and returns a verificationResult in the response body.
+      summary: Verifies a Presentation and all contained Verifiable Credentials, returning detailed verification results.
       tags:
        - Presentations
       security:
@@ -53,7 +53,25 @@ paths:
        - zCap: []
       operationId: verifyPresentation
       x-expectedCaller: "Verification Coordinator"
-      description: Verifies a verifiablePresentation and returns a verificationResult in the response body.  Given the possibility of denial of service, buffer overflow, or other style attacks, an implementation is permitted to rate limit or restrict requests against this API endpoint to those requests that contain only a single credential with a 413 or 429 error code as appropriate.
+      description: |
+        Verifies a verifiablePresentation and, by default, all verifiable credentials
+        contained within it.
+        
+        The verification process includes verifying the presentation's own proof (including domain
+        and challenge validation if provided), verifying each contained verifiable credential's proof, 
+        status, and validity periods, checking that the holder in the presentation matches the
+        verification method used in the presentation's proof.
+        
+        Business rule validation (such as verifying that credential subjects match the presentation holder)
+        is outside the scope of this verification endpoint and should be performed by the calling application.
+
+        API is compositional: when credential verification is disabled or limited via 
+        implementation-specific options, individual credentials can be verified separately 
+        using the /credentials/verify endpoint.
+        
+        Given the possibility of denial of service, buffer overflow, or other style attacks, an implementation 
+        is permitted to rate limit or restrict requests against this API endpoint to those requests that 
+        contain only a single credential with a 413 or 429 error code as appropriate.
       requestBody:
         content:
           application/json:
@@ -65,13 +83,21 @@ paths:
         description: Parameters for verifying a verifiablePresentation.
       responses:
         "200":
-          description: Verifiable Presentation successfully verified!
+          description: |
+
+            Verification process completed successfully. The response body contains detailed results 
+            indicating whether the presentation and its credentials passed or failed verification. 
+            A 200 status indicates the verification process itself succeeded, regardless of whether 
+            the presentation/credentials were determined to be valid or invalid.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/VerifyPresentationResponse"
         "400":
-          description: Invalid or malformed input
+          description: |
+            Invalid or malformed input that prevented the verification process from being performed. 
+            This indicates issues with the request format, structure, or parameters rather than 
+            verification failures.
         "413":
           description: Payload too large
         "429":

--- a/verifier.yml
+++ b/verifier.yml
@@ -70,8 +70,8 @@ paths:
         using the <code>/credentials/verify</code> endpoint.
         
         Given the possibility of denial of service, buffer overflow, or other attacks, an implementation 
-        is permitted to apply rate limits or restrict requests against this API endpoint as needed using
-        a <code>413</code> or <code>429</code> response error code as appropriate.
+        is permitted to apply rate limits or otherwise restrict requests against this API endpoint 
+        as needed using a <code>413</code>, <code>429</code>, or other response error code as appropriate.
       requestBody:
         content:
           application/json:

--- a/verifier.yml
+++ b/verifier.yml
@@ -44,7 +44,7 @@ paths:
           description: invalid input!
   /presentations/verify:
     post:
-      summary: Verifies a Presentation and all contained Verifiable Credentials, returning detailed verification results.
+      summary: Verifies a Presentation and all Verifiable Credentials it contains, returning detailed verification results.
       tags:
        - Presentations
       security:
@@ -58,20 +58,20 @@ paths:
         contained within it.
         
         The verification process includes verifying the presentation's own proof (including domain
-        and challenge validation if provided), verifying each contained verifiable credential's proof, 
-        status, and validity periods, checking that the holder in the presentation matches the
+        and challenge validation, if provided); verifying each contained verifiable credential's proof, 
+        status, and validity period(s); and checking that the holder in the presentation matches the
         verification method used in the presentation's proof.
         
         Business rule validation (such as verifying that credential subjects match the presentation holder)
         is outside the scope of this verification endpoint and should be performed by the calling application.
 
-        API is compositional: when credential verification is disabled or limited via 
+        The API is compositional: when credential verification is disabled or limited via 
         implementation-specific options, individual credentials can be verified separately 
-        using the /credentials/verify endpoint.
+        using the <code>/credentials/verify</code> endpoint.
         
-        Given the possibility of denial of service, buffer overflow, or other style attacks, an implementation 
-        is permitted to rate limit or restrict requests against this API endpoint to those requests that 
-        contain only a single credential with a 413 or 429 error code as appropriate.
+        Given the possibility of denial of service, buffer overflow, or other attacks, an implementation 
+        is permitted to apply rate limits or restrict requests against this API endpoint to those requests that 
+        contain only a single credential, with a <code>413</code> or <code>429</code> error code as appropriate.
       requestBody:
         content:
           application/json:
@@ -86,9 +86,9 @@ paths:
           description: |
 
             Verification process completed successfully. The response body contains detailed results 
-            indicating whether the presentation and its credentials passed or failed verification. 
-            A 200 status indicates the verification process itself succeeded, regardless of whether 
-            the presentation/credentials were determined to be valid or invalid.
+            indicating whether the presentation and its contained credentials passed or failed verification. 
+            A <code>200</code> status indicates the verification process itself succeeded, regardless of whether 
+            the presentation and/or credentials were determined to be valid or invalid.
           content:
             application/json:
               schema:
@@ -96,7 +96,7 @@ paths:
         "400":
           description: |
             Invalid or malformed input that prevented the verification process from being performed. 
-            This indicates issues with the request format, structure, or parameters rather than 
+            This indicates issues with the request format, structure, or parameters, rather than 
             verification failures.
         "413":
           description: Payload too large

--- a/verifier.yml
+++ b/verifier.yml
@@ -71,7 +71,7 @@ paths:
         
         Given the possibility of denial of service, buffer overflow, or other attacks, an implementation 
         is permitted to apply rate limits or otherwise restrict requests against this API endpoint 
-        as needed using a <code>413</code>, <code>429</code>, or other response error code as appropriate.
+        as needed, using a <code>413</code>, <code>429</code>, or other response error code as appropriate.
       requestBody:
         content:
           application/json:

--- a/verifier.yml
+++ b/verifier.yml
@@ -70,8 +70,8 @@ paths:
         using the <code>/credentials/verify</code> endpoint.
         
         Given the possibility of denial of service, buffer overflow, or other attacks, an implementation 
-        is permitted to apply rate limits or restrict requests against this API endpoint to those requests that 
-        contain only a single credential, with a <code>413</code> or <code>429</code> error code as appropriate.
+        is permitted to apply rate limits or restrict requests against this API endpoint as needed using
+        a <code>413</code> or <code>429</code> response error code as appropriate.
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
- Updates specification text to explicitly state VP verification includes all contained VCs by default
- Updates POST /presentations/verify endpoint to reflect comprehensive verification of presentations and contained credentials
- Adds extensibility for implementer options to disable credential verification for debugging purposes
- Documents compositional API design enabling use of /credentials/verify for individual credential verification when VP credential checking is disabled
- Clarifies verification vs validation boundaries with business rules handled by calling applications
- Enhances HTTP response descriptions in /presentations/verify endpoint to clarify process success vs verification outcomes


To my understanding above updates are sufficient.

----
**Updates are highlighted**
----

_Section 3.9.2_
----

<img width="862" height="454" alt="VP Verify Description" src="https://github.com/user-attachments/assets/256a9618-ea14-41cc-96b0-f117049aff09" />

<img width="721" height="262" alt="Screenshot 2025-08-01 at 3 48 33 PM" src="https://github.com/user-attachments/assets/fdbc840a-00b0-416d-8654-ae2690733d43" />


_`verifier.html` displays from `verifier.yml`_
----
<img width="925" height="681" alt="Screenshot 2025-08-01 at 3 39 33 PM" src="https://github.com/user-attachments/assets/822ff764-47f9-4ddf-913c-1791246cf367" />

[
<img width="654" height="488" alt="Screenshot 2025-08-01 at 3 46 54 PM" src="https://github.com/user-attachments/assets/4d9b7dae-3404-4967-867b-a6b656cfe315" />
](url)


---- 

Question for reviewers: Do we need to update the schema in the `/components/VerifyPresentationResult.yml` file?
  
Addresses #284.

@dlongley @msporny @TallTed - ready for review.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bparth24/vc-api/pull/508.html" title="Last updated on Aug 6, 2025, 3:12 PM UTC (01ae6be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/508/be5922a...bparth24:01ae6be.html" title="Last updated on Aug 6, 2025, 3:12 PM UTC (01ae6be)">Diff</a>